### PR TITLE
Crag routes responsive layout

### DIFF
--- a/src/app/common/ascent-type/ascent-type.component.html
+++ b/src/app/common/ascent-type/ascent-type.component.html
@@ -1,11 +1,19 @@
 <ng-container *ngIf="displayType=='text'">
-  <span *ngIf="ascentType" [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)">{{ ascentType.label }}
-    <span class="toprope" *ngIf="topRope"> (top rope)</span></span>
-  <span *ngIf="ascentType == null"><i>{{ type }}</i></span>
+  <span *ngIf="ascentType"
+        [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)">{{ ascentType.label }}
+    <span class="toprope"
+          *ngIf="topRope"> (top rope)</span>
+  </span>
+  <span *ngIf="ascentType == null">
+    <i>{{ type }}</i>
+  </span>
 </ng-container>
 <ng-container *ngIf="displayType=='icon'">
-  <span *ngIf="ascentType" [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)"
-    [matTooltip]="ascentType.label"><button mat-button>
+  <span *ngIf="ascentType"
+        [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)"
+        [matTooltip]="ascentType.label">
+    <button mat-button>
       <mat-icon>{{ icon }}</mat-icon>
-    </button></span>
+    </button>
+  </span>
 </ng-container>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -35,28 +35,30 @@
               {{ route.name }}
             </a>
           </div>
-          <div class="route-length">{{ route.length }} m</div>
-          <div class="route-grade" (mouseenter)="displayRouteGrades(route)" (mouseleave)="hideRouteGrades(route)">
-            <app-grade [grade]="route.grade" [text]="route.difficulty" [showModifier]="true"></app-grade>
-            <div class="popover" *ngIf="activeGradesPopupId === route.id && !routeGradesLoading">
-              <!-- TODO move to separate component or make a directive out of this -->
-              <div class="popover-title">Ocene smeri {{ route.name }}</div>
-              <table>
-                <tbody>
-                  <tr *ngFor="let grade of routeGrades" [ngClass]="grade.includedInCalculation ? 'grade-included' : ''">
-                    <td>
-                      <app-grade class="grade" [grade]="grade.grade"></app-grade>
-                    </td>
-                    <td class="grade-author">
-                      <ng-container *ngIf="grade.isBase">Bazna ocena</ng-container>
-                      <ng-container *ngIf="!grade.isBase && grade.user">{{ grade.user.firstname + ' ' + grade.user.lastname
-                        }}</ng-container>
-                    </td>
-                    <td class="grade-date">{{ grade.created | amDateFormat:'D. M. Y' }}</td>
-                  </tr>
-                </tbody>
-              </table>
-              <div class="popover-arrow"></div>
+          <div class="route-numbers">
+            <div class="route-length">{{ route.length + ' m' }}</div>
+            <div class="route-grade" (mouseenter)="displayRouteGrades(route)" (mouseleave)="hideRouteGrades(route)">
+              <app-grade [grade]="route.grade" [text]="route.difficulty" [showModifier]="true"></app-grade>
+              <div class="popover" *ngIf="activeGradesPopupId === route.id && !routeGradesLoading">
+                <!-- TODO move to separate component or make a directive out of this -->
+                <div class="popover-title">Ocene smeri {{ route.name }}</div>
+                <table>
+                  <tbody>
+                    <tr *ngFor="let grade of routeGrades" [ngClass]="grade.includedInCalculation ? 'grade-included' : ''">
+                      <td>
+                        <app-grade class="grade" [grade]="grade.grade"></app-grade>
+                      </td>
+                      <td class="grade-author">
+                        <ng-container *ngIf="grade.isBase">Bazna ocena</ng-container>
+                        <ng-container *ngIf="!grade.isBase && grade.user">{{ grade.user.firstname + ' ' + grade.user.lastname
+                          }}</ng-container>
+                      </td>
+                      <td class="grade-date">{{ grade.created | amDateFormat:'D. M. Y' }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+                <div class="popover-arrow"></div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -4,7 +4,7 @@
     <span>{{ sector.name != "" ? " - " + sector.name : "" }}</span>
   </h3>
   <div class="card">
-    <div fxLayout="row" fxLayoutAlign="start center" fxHide.lt-md class="row header" fxLayoutGap="14px">
+    <div class="row header route-row" fxLayoutGap="14px">
       <div class="route-checkbox"></div>
       <div class="route-details-container">
         <div class="route-details left" fxLayoutGap="14px">
@@ -17,12 +17,12 @@
         </div>
       </div>
     </div>
-    <div *ngFor="let route of sector.routes" fxLayout="row" fxLayoutAlign="start center" class="row" fxLayoutGap="14px">
+    <div *ngFor="let route of sector.routes" class="row route-row" fxLayoutGap="14px">
       <div class="route-checkbox">
         <mat-checkbox (change)="changeSelection(route)" [checked]="selectedRoutesIds.indexOf(route.id) > -1">
         </mat-checkbox>
       </div>
-      <div class="route-details-container" [ngClass.lt-sm]="{ 'column': true }">
+      <div class="route-details-container">
         <div class="route-details left" fxLayoutGap="14px">
           <div class="route-name">
             <a [routerLink]="[
@@ -60,7 +60,7 @@
             </div>
           </div>
         </div>
-        <div class="route-details right" fxLayoutGap="14px" [ngClass.lt-sm]="{ 'compact': true }">
+        <div class="route-details right" fxLayoutGap="14px">
           <div class="route-icons">
             <div *ngIf="route.pitches.length > 0" class="popover-container">
               <button mat-icon-button color="primary" (mouseenter)="displayRoutePitches(route)"

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -16,10 +16,6 @@
           <div class="route-icons"></div>
         </div>
       </div>
-      <div fxFlex="100">Ime</div>
-      <div fxFlex="80px" fxFlex.lt-md>Dolžina</div>
-      <div fxFlex="80px" fxFlex.lt-md>Težavnost</div>
-      <div fxFlex="160px"></div>
     </div>
     <div *ngFor="let route of sector.routes" fxLayout="row" fxLayoutAlign="start center" class="row" fxLayoutGap="14px">
       <div class="route-checkbox">
@@ -96,7 +92,7 @@
                         <span>{{ comment.created | amDateFormat:'D. M. Y' }}</span>
                       </div>
                     </div>
-                  </div>
+                  </ng-container>
                   <div class="popover-arrow"></div>
                 </div>
                 <app-ascent-type *ngIf="ascents[route.id] != null" [value]="ascents[route.id]" displayType="icon">

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -5,87 +5,109 @@
   </h3>
   <div class="card">
     <div fxLayout="row" fxLayoutAlign="start center" fxHide.lt-md class="row header" fxLayoutGap="14px">
-      <div fxFlex="12px"></div>
+      <div class="route-checkbox"></div>
+      <div class="route-details-container">
+        <div class="route-details left" fxLayoutGap="14px">
+          <div class="route-name">Ime</div>
+          <div class="route-length">Dolžina</div>
+          <div class="route-grade">Težavnost</div>
+        </div>
+        <div class="route-details right" fxLayoutGap="14px">
+          <div class="route-icons"></div>
+        </div>
+      </div>
       <div fxFlex="100">Ime</div>
       <div fxFlex="80px" fxFlex.lt-md>Dolžina</div>
       <div fxFlex="80px" fxFlex.lt-md>Težavnost</div>
       <div fxFlex="160px"></div>
     </div>
     <div *ngFor="let route of sector.routes" fxLayout="row" fxLayoutAlign="start center" class="row" fxLayoutGap="14px">
-
-      <div fxFlex="12px">
+      <div class="route-checkbox">
         <mat-checkbox (change)="changeSelection(route)" [checked]="selectedRoutesIds.indexOf(route.id) > -1">
         </mat-checkbox>
       </div>
-      <div fxFlex="100">
-        <a [routerLink]="[
-            '/plezalisca/',
-            crag.country.slug,
-            crag.slug,
-            route.id
-          ]">{{ route.name }}</a>
-      </div>
-      <div fxFlex="80px" fxFlex.lt-md fxHide.lt-md>{{ route.length }} m</div>
-      <div fxFlex="80px" fxFlex.lt-md (mouseenter)="displayRouteGrades(route)" (mouseleave)="hideRouteGrades(route)"
-        class="popover-container">
-        <app-grade [grade]="route.grade" [text]="route.difficulty" [showModifier]="true"></app-grade>
-        <div class="popover" *ngIf="activeGradesPopupId === route.id && !routeGradesLoading">
-          <div class="popover-title">Ocene smeri {{ route.name }}</div>
-          <table>
-            <tbody>
-              <tr *ngFor="let grade of routeGrades" [ngClass]="grade.includedInCalculation ? 'grade-included' : ''">
-                <td>
-                  <app-grade class="grade" [grade]="grade.grade"></app-grade>
-                </td>
-                <td class="grade-author">
-                  <ng-container *ngIf="grade.isBase">Bazna ocena</ng-container>
-                  <ng-container *ngIf="!grade.isBase && grade.user">{{ grade.user.firstname + ' ' + grade.user.lastname
-                    }}</ng-container>
-                </td>
-                <td class="grade-date">{{ grade.created | amDateFormat:'D. M. Y' }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <div class="popover-arrow"></div>
-        </div>
-      </div>
-
-      <div fxLayout="row" fxFlex="160px" fxLayoutAlign="center" class="icons">
-        <div *ngIf="route.pitches.length > 0" class="popover-container">
-          <button mat-icon-button color="primary" (mouseenter)="displayRoutePitches(route)"
-            (mouseleave)="hideRoutePitches(route)">MP</button>
-          <div class="popover" *ngIf="activePitchesPopupId === route.id">
-            <div class="popover-title">Raztežaji</div>
-            <div>
-              <text *ngFor="let pitch of route.pitches; let isLast=last">{{ pitch.difficulty }} {{ isLast ? '' : ', '
-                }}</text>
+      <div class="route-details-container" [ngClass.lt-sm]="{ 'column': true }">
+        <div class="route-details left" fxLayoutGap="14px">
+          <div class="route-name">
+            <a [routerLink]="[
+                '/plezalisca/',
+                crag.country.slug,
+                crag.slug,
+                route.id
+              ]"
+            >
+              {{ route.name }}
+            </a>
+          </div>
+          <div class="route-length">{{ route.length }} m</div>
+          <div class="route-grade" (mouseenter)="displayRouteGrades(route)" (mouseleave)="hideRouteGrades(route)">
+            <app-grade [grade]="route.grade" [text]="route.difficulty" [showModifier]="true"></app-grade>
+            <div class="popover" *ngIf="activeGradesPopupId === route.id && !routeGradesLoading">
+              <!-- TODO move to separate component or make a directive out of this -->
+              <div class="popover-title">Ocene smeri {{ route.name }}</div>
+              <table>
+                <tbody>
+                  <tr *ngFor="let grade of routeGrades" [ngClass]="grade.includedInCalculation ? 'grade-included' : ''">
+                    <td>
+                      <app-grade class="grade" [grade]="grade.grade"></app-grade>
+                    </td>
+                    <td class="grade-author">
+                      <ng-container *ngIf="grade.isBase">Bazna ocena</ng-container>
+                      <ng-container *ngIf="!grade.isBase && grade.user">{{ grade.user.firstname + ' ' + grade.user.lastname
+                        }}</ng-container>
+                    </td>
+                    <td class="grade-date">{{ grade.created | amDateFormat:'D. M. Y' }}</td>
+                  </tr>
+                </tbody>
+              </table>
+              <div class="popover-arrow"></div>
             </div>
           </div>
-          <div class="popover-arrow"></div>
         </div>
-        <div *ngIf="route.comments.length > 0" class="popover-container">
-          <button mat-icon-button (mouseenter)="displayRouteComments(route)" (mouseleave)="hideRouteComments(route)">
-            <mat-icon>comment</mat-icon>
-          </button>
-          <div class="popover comments" *ngIf="activeCommentsPopupId === route.id && !routeCommentsLoading">
-            <div class="popover-title">Komentarji</div>
-            <div>
-              <ng-container *ngFor="let comment of routeComments; let i = index">
-                <div class="row route-comment" [ngClass]="{ first: i === 0 }">
-                  <div class="route-comment-content">{{ comment.content }}</div>
-                  <div class="route-comment-author">
-                    <span *ngIf="comment.user">{{ comment.user.firstname + ' ' + comment.user.lastname + ', '
-                      }}</span>
-                    <span>{{ comment.created | amDateFormat:'D. M. Y' }}</span>
-                  </div>
+        <div class="route-details right" fxLayoutGap="14px" [ngClass.lt-sm]="{ 'compact': true }">
+          <div class="route-icons">
+            <div *ngIf="route.pitches.length > 0" class="popover-container">
+              <button mat-icon-button color="primary" (mouseenter)="displayRoutePitches(route)"
+                (mouseleave)="hideRoutePitches(route)">MP</button>
+              <div class="popover" *ngIf="activePitchesPopupId === route.id">
+                <!-- TODO move to separate component or make a directive out of this -->
+                <div class="popover-title">Raztežaji</div>
+                <div>
+                  <text *ngFor="let pitch of route.pitches; let isLast=last">{{ pitch.difficulty }} {{ isLast ? '' : ', '
+                    }}</text>
                 </div>
-              </ng-container>
+              </div>
+              <div class="popover-arrow"></div>
             </div>
+            <div *ngIf="route.comments.length > 0" class="popover-container">
+              <button mat-icon-button (mouseenter)="displayRouteComments(route)" (mouseleave)="hideRouteComments(route)">
+                <mat-icon>comment</mat-icon>
+              </button>
+              <div class="popover comments" *ngIf="activeCommentsPopupId === route.id && !routeCommentsLoading">
+                <!-- TODO move to separate component or make a directive out of this -->
+                <div class="popover-title">Komentarji</div>
+                <div>
+                  <ng-container *ngFor="let comment of routeComments; let i = index">
+                    <div class="row route-comment" [ngClass]="{ first: i === 0 }">
+                      <div class="route-comment-content">{{ comment.content }}</div>
+                      <div class="route-comment-author">
+                        <span *ngIf="comment.user">{{ comment.user.firstname + ' ' + comment.user.lastname + ', '
+                          }}</span>
+                        <span>{{ comment.created | amDateFormat:'D. M. Y' }}</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="popover-arrow"></div>
+                </div>
+                <app-ascent-type *ngIf="ascents[route.id] != null" [value]="ascents[route.id]" displayType="icon">
+                </app-ascent-type>
+                <span class="ascent-type-filler" *ngIf="ascents[route.id] == undefined"></span>
+              </div>
+            </div>
+            <app-ascent-type *ngIf="ascents[route.id] != null" [value]="ascents[route.id]" displayType="icon">
+            </app-ascent-type>
           </div>
-          <div class="popover-arrow"></div>
         </div>
-        <app-ascent-type *ngIf="ascents[route.id] != null" [value]="ascents[route.id]" displayType="icon">
-        </app-ascent-type>
       </div>
     </div>
   </div>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -1,22 +1,97 @@
 @import "~@angular/material/theming";
 @import "../../../../styles/colors.scss";
 
-.row {
-  // cursor: pointer;
+.route-row {
+  display: flex;
+  flex-direction: row;
   padding: 6px 2px 6px 10px;
+  // TODO gap
+}
 
-  .icons {
-    white-space: nowrap;
-    text-align: center;
-    margin: -4px 0;
+.route-details-container {
+  flex: 1 1 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  text-align: left;
 
-    .mat-icon-button {
-      color: #0000008a;
-      height: 37px;
-      width: 37px;
-    }
+  // TODO: column on small
+
+  &.column {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+.route-details {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+  // TODO gap
+
+  &.left {
+    flex: 1 1 100%;
   }
 
+  &.right {
+    flex: 0 0 254px;
+
+    &.compact {
+      flex: 1 1 100%;
+      white-space: nowrap;
+      justify-content: space-between;
+    }
+  }
+}
+
+.route-checkbox {
+  flex: 0 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.route-name {
+  flex: 1 1 100%;
+}
+
+.route-length {
+  flex: 0 0 80px;
+}
+
+.route-grade {
+  flex: 0 0 80px;
+  position: relative;
+}
+
+.route-pitches {
+  flex: 0 0 80px;
+}
+
+.route-icons {
+  flex: 0 0 160px;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+  white-space: nowrap;
+  text-align: right;
+  margin: -4px 0;
+
+  .mat-button {
+    color: #0000008a;
+  }
+
+  .mat-icon-button {
+    color: #0000008a;
+    height: 37px;
+    width: 37px;
+  }
+}
+
+.row {
   &.header {
     cursor: default;
     padding-top: 12px;

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -25,11 +25,6 @@
   justify-content: flex-start;
   align-items: center;
   text-align: left;
-
-  @media (max-width: $breakpoint-sm) {
-    flex-direction: column;
-    align-items: stretch;
-  }
 }
 
 .route-details {
@@ -37,20 +32,20 @@
   flex-direction: row;
   justify-content: flex-start;
   align-items: center;
-  // TODO gap
 
   &.left {
     flex: 1 1 100%;
+
+    @media (max-width: $breakpoint-sm) {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: flex-start;
+    }
   }
 
   &.right {
     flex: 0 0 110px;
-
-    @media (max-width: $breakpoint-sm) {
-      flex: 1 1 100%;
-      white-space: nowrap;
-      justify-content: space-between;
-    }
   }
 }
 
@@ -63,6 +58,16 @@
 
 .route-name {
   flex: 1 1 100%;
+}
+
+.route-numbers {
+  display: flex;
+  flex: 0 0 160px;
+
+  @media (max-width: $breakpoint-sm) {
+    flex-direction: row;
+    flex: 1 1 auto;
+  }
 }
 
 .route-length {
@@ -111,8 +116,6 @@ h3 {
 
 .popover-container {
   position: relative;
-
-  // text-align: center;
 }
 .pitches {
   text-align: center;

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -1,11 +1,21 @@
 @import "~@angular/material/theming";
 @import "../../../../styles/colors.scss";
+@import "../../../../styles/variables.scss";
 
 .route-row {
   display: flex;
   flex-direction: row;
   padding: 6px 2px 6px 10px;
   // TODO gap
+
+  &.header {
+    cursor: default;
+    padding-top: 12px;
+
+    @media (max-width: 959px) {
+      display: none;
+    }
+  }
 }
 
 .route-details-container {
@@ -16,9 +26,7 @@
   align-items: center;
   text-align: left;
 
-  // TODO: column on small
-
-  &.column {
+  @media (max-width: $breakpoint-sm) {
     flex-direction: column;
     align-items: stretch;
   }
@@ -38,7 +46,7 @@
   &.right {
     flex: 0 0 110px;
 
-    &.compact {
+    @media (max-width: $breakpoint-sm) {
       flex: 1 1 100%;
       white-space: nowrap;
       justify-content: space-between;
@@ -91,12 +99,6 @@
   }
 }
 
-.row {
-  &.header {
-    cursor: default;
-    padding-top: 12px;
-  }
-}
 
 h3 {
   padding-top: 28px;

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -36,7 +36,7 @@
   }
 
   &.right {
-    flex: 0 0 254px;
+    flex: 0 0 110px;
 
     &.compact {
       flex: 1 1 100%;
@@ -71,7 +71,7 @@
 }
 
 .route-icons {
-  flex: 0 0 160px;
+  flex: 0 0 110px;
   display: flex;
   flex-direction: row;
   justify-content: flex-end;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,0 +1,6 @@
+// These breakpoitns are used by flex-layout and should be used where we want to write our own CSS instead of using flex-layout.
+// https://github.com/angular/flex-layout/wiki/Responsive-API#mediaqueries-and-aliases
+$breakpoint-sm: 599px;
+$breakpoint-md: 959px;
+$breakpoint-lg: 1279px;
+$breakpoint-xl: 1919px;


### PR DESCRIPTION
This PR makes changes to crag routes rows. The route rows now wrap into two rows on mobile and the icons stay aligned to the right edge. I know that this isn't perfect but it's better than before. Hopefully the designer will have a better idea.

I also replaced `flex-layout` properties because the rendering of the bigger tables (e.g.: Osp, Kotečnik) was pretty slow. I suggest we minimise use of the library in tables.

**Desktop size example. Not very different.**

![image](https://user-images.githubusercontent.com/6022408/144653421-e749e7bb-e72b-417a-b557-1253de3255ee.png)

**Mobile size:**

![image](https://user-images.githubusercontent.com/6022408/144653523-59ec9fee-6ed2-4208-b716-0f9b33027608.png)
