### PR TITLE
Fix fit 2 markers on the map

### DIFF
--- a/src/app/common/map/map.component.ts
+++ b/src/app/common/map/map.component.ts
@@ -126,6 +126,7 @@ export class MapComponent implements OnInit, AfterViewInit {
         this.map.getView().fit(this.vectorLayer.getSource().getExtent(), {
           size: this.map.getSize(),
           maxZoom: 15,
+          padding: [30, 30, 30, 30]
         });
       }
     });

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -123,7 +123,7 @@ export class CragRoutesComponent implements OnInit {
     this.myCragSummaryGQL
       .watch({ input: { cragId: this.crag.id } })
       .valueChanges.subscribe((result) => {
-        result.data.myCragSummary.forEach((ascent) => {
+        result.data?.myCragSummary.forEach((ascent) => {
           this.ascents[ascent.route.id] = ascent.ascentType;
         });
       });


### PR DESCRIPTION
Added some padding when fitting markers. For some reason just `size: this.map.getSize(),` is not enough.

Another thing: fixing when user is logged in and visits page for a specific crag. Then he logs out, and is redirected to ˙/˙, but `myCragSummaryGQL` subscription is still triggered. Because use is now logged out, `data` property is `null`. This results in null reference exception.

Closes #66 