### PR TITLE
Route count as cache key

### DIFF
--- a/src/app/graphql/graphql.module.ts
+++ b/src/app/graphql/graphql.module.ts
@@ -19,6 +19,7 @@ export function createApollo(httpLink: HttpLink): ApolloClientOptions<any> {
               },
             },
           },
+          keyFields: ['id', 'nrRoutes'],
         },
         Club: {
           fields: {


### PR DESCRIPTION
Apollo cached Crag objects but did not consider that nrRoutes can change according to query parameters. 
The nrRoutes field was added to cache key calculation.