### PR TITLE
Revert "Route count as cache key"

### DIFF
--- a/src/app/graphql/graphql.module.ts
+++ b/src/app/graphql/graphql.module.ts
@@ -19,7 +19,6 @@ export function createApollo(httpLink: HttpLink): ApolloClientOptions<any> {
               },
             },
           },
-          keyFields: ['id', 'nrRoutes'],
         },
         Club: {
           fields: {


### PR DESCRIPTION
Reverts plezanje-net/web#98

just realized that crag page does not work after this change...
getting error: 'Invariant Violation: Missing field 'nrRoutes' while extracting keyFields from...'