### PR TITLE
Add service for converting diff to grade based on grading system

### DIFF
--- a/src/app/common/grade/grade.component.html
+++ b/src/app/common/grade/grade.component.html
@@ -1,8 +1,10 @@
-<span class="grade-name">{{ legacy ? grade.legacyName : grade.name }}<ng-container *ngIf="showModifier"> </ng-container>
-</span>
-<span *ngIf="showModifier && grade.modifier == 1" class="grade-modifier hard">
-  <mat-icon>arrow_drop_up</mat-icon>
-</span>
-<span *ngIf="showModifier && grade.modifier == -1" class="grade-modifier soft">
-  <mat-icon>arrow_drop_down</mat-icon>
-</span>
+<ng-container *ngIf="grade">
+  <span class="grade-name">{{ grade.name }}<ng-container *ngIf="showModifier"> </ng-container>
+  </span>
+  <span *ngIf="showModifier && grade.modifier == 1" class="grade-modifier hard">
+    <mat-icon>arrow_drop_up</mat-icon>
+  </span>
+  <span *ngIf="showModifier && grade.modifier == -1" class="grade-modifier soft">
+    <mat-icon>arrow_drop_down</mat-icon>
+  </span>
+</ng-container>

--- a/src/app/common/grade/grade.component.ts
+++ b/src/app/common/grade/grade.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { Grade } from '../grade';
+// import { Grade } from '../grade';
+import { GradingSystemsService, IGrade } from '../../shared/services/grading-systems.service'
 
 @Component({
   selector: 'app-grade',
@@ -12,14 +13,19 @@ export class GradeComponent implements OnInit {
   @Input('modifier') showModifier: boolean = false;
   @Input() legacy: boolean = false;
 
-  grade: Grade;
+  // grade: Grade;
+  grade: IGrade;
   modifier: number = 0;
 
   gradeLetters = ['a', 'a+', 'b', 'b+', 'c', 'c+'];
 
-  constructor() {}
+  constructor(private GradingSystemsService: GradingSystemsService) {}
 
   ngOnInit(): void {
-    this.grade = new Grade(this.difficulty);
+    // this.grade = new Grade(this.difficulty);
+    this.GradingSystemsService.diffToGrade(this.difficulty, 'french', this.legacy).then((name) => {
+      this.grade = name;
+      // console.log({ ...name, diff: this.difficulty});
+    });
   }
 }

--- a/src/app/shared/services/grading-systems.query.graphql
+++ b/src/app/shared/services/grading-systems.query.graphql
@@ -1,0 +1,11 @@
+query GradingSystems {
+  gradingSystems {
+    name
+    id
+    grades {
+      difficulty
+      name
+      id
+    }
+  }
+}

--- a/src/app/shared/services/grading-systems.service.spec.ts
+++ b/src/app/shared/services/grading-systems.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { GradingSystemsService } from './grading-systems.service';
+
+describe('GradingSystemsService', () => {
+  let service: GradingSystemsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(GradingSystemsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/shared/services/grading-systems.service.ts
+++ b/src/app/shared/services/grading-systems.service.ts
@@ -1,0 +1,122 @@
+import { Injectable } from '@angular/core';
+import { GradingSystemsGQL } from 'src/generated/graphql';
+
+interface IGradingSystems {
+  id: string;
+  name: string;
+  grades: {
+    name: string;
+    difficulty: number;
+  }[];
+}
+
+export interface IGrade {
+  name: string;
+  modifier: -1 | 0 | 1; // -1 means the grade is soft, +1 means it's hard
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class GradingSystemsService {
+  gradingSystems: { id: string; name: string; grades: { difficulty: number; name: string }[] }[];
+
+  constructor(private GradingSystemsGQL: GradingSystemsGQL) {}
+
+  private getGradingSystems(): Promise<IGradingSystems[]> {
+    // TODO save the promise to prevent multiple requests
+    return new Promise(async (resolve) => {
+      if (!this.gradingSystems) {
+        const result = await this.GradingSystemsGQL.fetch().toPromise();
+        this.gradingSystems = result.data.gradingSystems;
+        resolve(this.gradingSystems);
+      } else {
+        resolve(this.gradingSystems);
+      }
+    });
+  }
+
+  diffToGrade(difficulty: number, gradingSystemId: string, legacy: boolean = false): Promise<IGrade> {
+    return new Promise((resolve, reject) => {
+      this.getGradingSystems()
+        .then((gradingSystems) => {
+          const grades = gradingSystems.find((gradingSystem) => gradingSystem.id === gradingSystemId).grades;
+          // legacy grades should always be accurate and can only be found as grade suggestions
+          // for example in the case of french grades, legacy grades should always have remainder 0 when dividing by 25
+          if (legacy) {
+            grades.forEach((grade) => {
+              if (grade.difficulty === difficulty) {
+                resolve({
+                  name: grade.name,
+                  modifier: 0,
+                });
+              }
+            });
+          } else {
+
+            // if lowest possible or highest possible grade, simply resolve without modifiers
+            if (difficulty <= grades[0].difficulty) {
+              return resolve({
+                name: grades[0].name,
+                modifier: 0,
+              });
+            } else if (difficulty >= grades[grades.length - 1].difficulty) {
+              return resolve({
+                name: grades[grades.length - 1].name,
+                modifier: 0,
+              });
+            }
+
+            // skip checks for lowest and highest possible grade
+            for (let i = 1; i < grades.length - 1; i++) {
+              const prev = grades[i - 1];
+              const curr = grades[i];
+              const next = grades[i + 1];
+
+              // loop until curr is the closest grade to the searched grade
+              if (Math.abs(curr.difficulty - difficulty) <= Math.abs(next.difficulty - difficulty)) {
+                if (difficulty < curr.difficulty) {
+                  const gradesMiddlemark = (curr.difficulty + prev.difficulty) / 2;
+
+                  if (Math.abs(curr.difficulty - difficulty) < Math.abs(gradesMiddlemark - difficulty)) {
+                    return resolve({
+                      name: curr.name,
+                      modifier: 0
+                    });
+                  } else {
+                    return resolve({
+                      name: curr.name,
+                      modifier: -1
+                    });
+                  }
+                } else if (difficulty > curr.difficulty) {
+                  const gradesMiddlemark = (curr.difficulty + next.difficulty) / 2;
+
+                  if (Math.abs(curr.difficulty - difficulty) <= Math.abs(gradesMiddlemark - difficulty)) {
+                    return resolve({
+                      name: curr.name,
+                      modifier: 0,
+                    });
+                  } else {
+                    return resolve({
+                      name: curr.name,
+                      modifier: +1,
+                    });
+                  }
+                } else {
+                  return resolve({
+                    name: curr.name,
+                    modifier: 0,
+                  });
+                }
+              }
+
+            }
+          }
+        })
+        .catch(() => {
+          reject();
+        });
+    });
+  }
+}


### PR DESCRIPTION
This PR adds service `GradingSystemsService` which will be used to convert between grades and difficulties based on provided grading system.

I implemented method `diffToGrade` which returns the appropriate grade name and modifier for the provided difficulty. It can also convert to legacy grades but only if the provided difficulty is "accurate" (400, 425, 450 ...).

I think it should work for all grading systems because it loops over the array of grades instead of doing arithmetics. But I didn't test other than french yet because I want to confirm that this is the way to go first before I put in more time.

I noticed that this service converts diffs to grades differently than the Grade class but I think that this is accurate now.

**Example using `Grade.ts` class:**
<img width="674" alt="Screenshot 2021-12-22 at 20 24 46" src="https://user-images.githubusercontent.com/6022408/147146882-9b22bd57-f207-48ee-b090-59759a67f6ed.png">


**Example using `GradingSystemsService`:**
<img width="686" alt="Screenshot 2021-12-22 at 20 24 23" src="https://user-images.githubusercontent.com/6022408/147146868-f5bfc16c-4f96-44dd-ac9f-893c0005dc6d.png">


**Difference between old and new implementation**
Difficulty 716.6 would get displayed as 5a (not soft or hard) but now it's a hard 5a.
Difficulty 484 would get displayed as 4b (not soft or hard) but now it's a soft 4b.


I made this for easier development:
![image](https://user-images.githubusercontent.com/6022408/147147480-0863fd02-d823-4cea-9b20-737f81e86c84.png)
