### PR TITLE
Difficulty votes

### DIFF
--- a/src/app/common/activity.constants.ts
+++ b/src/app/common/activity.constants.ts
@@ -35,7 +35,7 @@ export const ASCENT_TYPES: AscentType[] = [
     label: 'Ponovitev',
     color: 'green',
     topRope: false,
-    tick: false,
+    tick: true,
   },
   {
     value: 'allfree',

--- a/src/app/forms/activity-form/activity-form-route/activity-form-route.component.html
+++ b/src/app/forms/activity-form/activity-form-route/activity-form-route.component.html
@@ -132,8 +132,9 @@
         <app-grade-select
           class="no-hint"
           fxFlex="25"
-          [control]="route.controls.difficultyVote"
+          [control]="route.controls.votedDifficulty"
           label="Predlog ocene"
+          [gradingSystemId]="route.value.defaultGradingSystemId"
         ></app-grade-select>
       </div>
       <div fxFlex="100" fxHide.lt-md></div>

--- a/src/app/forms/activity-form/activity-form-route/activity-form-route.component.html
+++ b/src/app/forms/activity-form/activity-form-route/activity-form-route.component.html
@@ -132,7 +132,7 @@
         <app-grade-select
           class="no-hint"
           fxFlex="25"
-          [control]="route.controls.gradeSuggestion"
+          [control]="route.controls.difficultyVote"
           label="Predlog ocene"
         ></app-grade-select>
       </div>

--- a/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import {
   ASCENT_TYPES,
@@ -6,13 +13,16 @@ import {
   PUBLISH_OPTIONS,
 } from '../../../common/activity.constants';
 import { Crag } from 'src/generated/graphql';
+import { Subject, takeUntil } from 'rxjs';
 
 @Component({
   selector: 'app-activity-form-route',
   templateUrl: './activity-form-route.component.html',
   styleUrls: ['./activity-form-route.component.scss'],
 })
-export class ActivityFormRouteComponent implements OnInit {
+export class ActivityFormRouteComponent implements OnInit, OnDestroy {
+  private destroy$ = new Subject<void>();
+
   @Input() activity = true;
   @Input() route: FormGroup;
   @Input() first: boolean;
@@ -47,5 +57,38 @@ export class ActivityFormRouteComponent implements OnInit {
         }
       }
     );
+
+    const ascentTypeSelected = this.route.get('ascentType').value;
+    this.conditionallyDisableVotedDifficulty(ascentTypeSelected);
+
+    this.route
+      .get('ascentType')
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((at) => this.conditionallyDisableVotedDifficulty(at));
+  }
+
+  /**
+   *
+   * @param ascentTypeSelected
+   *
+   * Make voting on difficulty possible only if a user is ticking a route
+   */
+  conditionallyDisableVotedDifficulty(ascentTypeSelected: string) {
+    const isTick = ASCENT_TYPES.some(
+      (at) => at.value === ascentTypeSelected && at.tick
+    );
+
+    // Only if route is being newly ticked or repeated (which also is a tick) can one cast a vote on difficulty (i.e. new vote or modifying existing one)
+    if (isTick) {
+      this.route.get('votedDifficulty').enable();
+    } else {
+      this.route.get('votedDifficulty').setValue(null);
+      this.route.get('votedDifficulty').disable();
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -38,6 +38,7 @@ export class ActivityFormRouteComponent implements OnInit {
           publish === PublishOptionsEnum.private &&
           !votedDifficultyControl.disabled
         ) {
+          votedDifficultyControl.reset();
           votedDifficultyControl.disable();
         } else {
           if (votedDifficultyControl.disabled) {

--- a/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -58,8 +58,17 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
         }
       });
 
+    // should disable possibility to vote on route if ascent type not a tick
+    const ascentTypeSelected = this.route.get('ascentType').value;
+    this.conditionallyDisableVotedDifficulty(ascentTypeSelected);
+
+    this.route
+      .get('ascentType')
+      .valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((at) => this.conditionallyDisableVotedDifficulty(at));
+
+    // if a route is a project than a vote on diff should always be cast
     if (this.route.get('isProject').value) {
-      const ascentTypeSelected = this.route.get('ascentType').value;
       this.conditionallyRequireVotedDifficulty(ascentTypeSelected);
 
       this.route
@@ -80,11 +89,11 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
       (at) => at.value === ascentTypeSelected && at.tick
     );
     if (isTick) {
-      this.route.get('gradeSuggestion').addValidators(Validators.required);
+      this.route.get('votedDifficulty').addValidators(Validators.required);
     } else {
-      this.route.get('gradeSuggestion').clearValidators();
+      this.route.get('votedDifficulty').clearValidators();
     }
-    this.route.get('gradeSuggestion').updateValueAndValidity();
+    this.route.get('votedDifficulty').updateValueAndValidity();
   }
 
   /**
@@ -97,7 +106,6 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
     const isTick = ASCENT_TYPES.some(
       (at) => at.value === ascentTypeSelected && at.tick
     );
-
     // Only if route is being newly ticked or repeated (which also is a tick) can one cast a vote on difficulty (i.e. new vote or modifying existing one)
     if (isTick) {
       this.route.get('votedDifficulty').enable();

--- a/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -1,11 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import {
   ASCENT_TYPES,
@@ -39,16 +32,16 @@ export class ActivityFormRouteComponent implements OnInit {
   ngOnInit(): void {
     this.route.controls.publish.valueChanges.subscribe(
       (publish: PublishOptionsEnum) => {
-        const difficultyVoteControl = this.route.controls.difficultyVote;
+        const votedDifficultyControl = this.route.controls.votedDifficulty;
 
         if (
           publish === PublishOptionsEnum.private &&
-          !difficultyVoteControl.disabled
+          !votedDifficultyControl.disabled
         ) {
-          difficultyVoteControl.disable();
+          votedDifficultyControl.disable();
         } else {
-          if (difficultyVoteControl.disabled) {
-            difficultyVoteControl.enable();
+          if (votedDifficultyControl.disabled) {
+            votedDifficultyControl.enable();
           }
         }
       }

--- a/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import {
   ASCENT_TYPES,
@@ -24,6 +31,7 @@ export class ActivityFormRouteComponent implements OnInit {
   nonTopRopeAscentTypes = ASCENT_TYPES.filter(
     (ascentType) => !ascentType.topRope
   );
+
   publishOptions = PUBLISH_OPTIONS;
 
   constructor() {}
@@ -31,16 +39,16 @@ export class ActivityFormRouteComponent implements OnInit {
   ngOnInit(): void {
     this.route.controls.publish.valueChanges.subscribe(
       (publish: PublishOptionsEnum) => {
-        const gradeSuggestionControl = this.route.controls.gradeSuggestion;
+        const difficultyVoteControl = this.route.controls.difficultyVote;
 
         if (
           publish === PublishOptionsEnum.private &&
-          !gradeSuggestionControl.disabled
+          !difficultyVoteControl.disabled
         ) {
-          gradeSuggestionControl.disable();
+          difficultyVoteControl.disable();
         } else {
-          if (gradeSuggestionControl.disabled) {
-            gradeSuggestionControl.enable();
+          if (difficultyVoteControl.disabled) {
+            difficultyVoteControl.enable();
           }
         }
       }

--- a/src/app/forms/activity-form/activity-form.component.ts
+++ b/src/app/forms/activity-form/activity-form.component.ts
@@ -81,7 +81,7 @@ export class ActivityFormComponent implements OnInit {
         publish: new FormControl('public'),
         notes: new FormControl(),
         stars: new FormControl(),
-        gradeSuggestion: new FormControl(),
+        difficultyVote: new FormControl(),
         ticked: new FormControl(route.ticked),
         tried: new FormControl(route.tried),
         type: new FormControl(route.type),
@@ -132,22 +132,19 @@ export class ActivityFormComponent implements OnInit {
       cragId: this.crag.id,
     };
 
-    const routes = this.routes.value.map((route: any, i: number) => ({
-      date: route.date || activity.date,
-      partner: route.partner || activity.partners,
-      ascentType: route.ascentType,
-      notes: route.notes,
-      position: i,
-      publish: route.publish,
-      routeId: route.routeId,
-      name: route.name,
-      difficulty: route.difficulty,
-      grade:
-        route.publish === PublishOptionsEnum.private
-          ? undefined
-          : route.gradeSuggestion,
-      stars: route.stars,
-    }));
+    const routes = this.routes.value.map((route: any, i: number) => {
+      return {
+        date: route.date || activity.date,
+        partner: route.partner || activity.partners,
+        ascentType: route.ascentType,
+        notes: route.notes,
+        position: i,
+        publish: route.publish,
+        routeId: route.routeId,
+        name: route.name,
+        stars: route.stars,
+      };
+    });
 
     this.createActivityGQL
       .mutate(

--- a/src/app/forms/activity-form/activity-form.component.ts
+++ b/src/app/forms/activity-form/activity-form.component.ts
@@ -10,7 +10,6 @@ import {
 import moment from 'moment';
 import { Router } from '@angular/router';
 import { LocalStorageService } from 'src/app/services/local-storage.service';
-import { PublishOptionsEnum } from 'src/app/common/activity.constants';
 
 @Component({
   selector: 'app-activity-form',
@@ -75,13 +74,14 @@ export class ActivityFormComponent implements OnInit {
         name: new FormControl(route.name),
         grade: new FormControl(route.grade),
         difficulty: new FormControl(route.difficulty),
+        defaultGradingSystemId: new FormControl(route.defaultGradingSystem.id),
         ascentType: new FormControl(!route?.ticked ? 'redpoint' : 'repeat'),
         date: new FormControl(),
         partner: new FormControl(),
         publish: new FormControl('public'),
         notes: new FormControl(),
         stars: new FormControl(),
-        difficultyVote: new FormControl(),
+        votedDifficulty: new FormControl(),
         ticked: new FormControl(route.ticked),
         tried: new FormControl(route.tried),
         type: new FormControl(route.type),
@@ -136,13 +136,14 @@ export class ActivityFormComponent implements OnInit {
       return {
         date: route.date || activity.date,
         partner: route.partner || activity.partners,
-        ascentType: route.ascentType,
         notes: route.notes,
-        position: i,
-        publish: route.publish,
         routeId: route.routeId,
-        name: route.name,
+        ascentType: route.ascentType,
         stars: route.stars,
+        publish: route.publish,
+        votedDifficulty: route.votedDifficulty,
+        name: route.name, // TODO: do we need this?
+        position: i, // TODO: why do we need this?
       };
     });
 

--- a/src/app/pages/crag/crag-by-slug.query.graphql
+++ b/src/app/pages/crag/crag-by-slug.query.graphql
@@ -27,6 +27,9 @@ query CragBySlug($crag: String!) {
         name
         slug
         difficulty
+        defaultGradingSystem {
+          id
+        }
         length
         routeType {
           id

--- a/src/app/shared/components/grade-select/grade-select.component.html
+++ b/src/app/shared/components/grade-select/grade-select.component.html
@@ -2,9 +2,16 @@
   <mat-label>{{ label }}</mat-label>
   <mat-select [formControl]="control">
     <mat-option>
-      <ngx-mat-select-search placeholderLabel="Vnesi oceno" [formControl]="gradeFilterControl"></ngx-mat-select-search>
+      <ngx-mat-select-search
+        [formControl]="gradeFilterControl"
+        placeholderLabel="Vnesi oceno"
+        noEntriesFoundLabel="Ocena ne obstaja"
+      ></ngx-mat-select-search>
     </mat-option>
-    <mat-option *ngFor="let option of filteredGradesOptions | async" [value]="option.number">{{ option.name }}
-    </mat-option>
+    <mat-option
+      *ngFor="let grade of filteredGrades"
+      [value]="grade.difficulty"
+      >{{ grade.name }}</mat-option
+    >
   </mat-select>
 </mat-form-field>

--- a/src/app/shared/components/grade-select/grade-select.component.html
+++ b/src/app/shared/components/grade-select/grade-select.component.html
@@ -8,6 +8,9 @@
         noEntriesFoundLabel="Ocena ne obstaja"
       ></ngx-mat-select-search>
     </mat-option>
+    <mat-option *ngIf="!gradeFilterControl.value" [value]="null"
+      >Ne vem</mat-option
+    >
     <mat-option
       *ngFor="let grade of filteredGrades"
       [value]="grade.difficulty"

--- a/src/app/shared/components/grade-select/grade-select.component.ts
+++ b/src/app/shared/components/grade-select/grade-select.component.ts
@@ -26,7 +26,6 @@ export class GradeSelectComponent implements OnInit {
     const gradingSystems = this.gradingSystemService.getGradingSystems();
 
     gradingSystems.then((gradingSystems) => {
-      console.log(gradingSystems);
       const grades = gradingSystems.find(
         (gradingSystem) => gradingSystem.id === this.gradingSystemId
       ).grades;


### PR DESCRIPTION
closes #121 

Sends user's vote on difficulty of a route when a user logs a route.

Test this by logging a route. Then check db if difficultyVote is added and check the route if difficulty is adjusted. 
You can try finding a route with such previous votes that your vote will change the grade.


Should discuss again about how to handle voting and private logs. Now for private logs (only for private) the vote control is simply disabled on FE.
Should probably add constraint ob BE or let users vote anyway and display such votes as anonymous. 

But I suggest that we keep all votes public and that privacy only affects the actual log.  Maybe we only need to clarify this to the user somehow...
