### PR TITLE
Fix route link on search autocomplete to use slug instead of id.

### DIFF
--- a/src/app/pages/search/search.component.ts
+++ b/src/app/pages/search/search.component.ts
@@ -107,7 +107,7 @@ export class SearchComponent implements OnInit, OnDestroy {
           '/plezalisca',
           route.crag.country.slug,
           route.crag.slug,
-          route.id,
+          route.slug,
         ]);
         break;
 


### PR DESCRIPTION
To test: go to home, start typing into search, click on a route from autocomplete dropdown