### PR TITLE
only load areas with crags in crag list view

### DIFF
--- a/src/app/pages/crags/crags.query.graphql
+++ b/src/app/pages/crags/crags.query.graphql
@@ -20,7 +20,7 @@ query Crags($country: String!, $input: FindCragsInput) {
       minDifficulty
       maxDifficulty
     }
-    areas {
+    areas(hasCrags: true) {
       id
       name
     }


### PR DESCRIPTION
After areas upgrade, the areas resolver on country entitiy takes a "hasCrags" param.  This is a fix that sets the new param to true in crags list query.
To test, open slovenia and see that only 10 areas are loaded in the TOC.