### PR TITLE
Hide height on boulders

### DIFF
--- a/src/app/pages/crag/crag-by-slug.query.graphql
+++ b/src/app/pages/crag/crag-by-slug.query.graphql
@@ -41,6 +41,7 @@ query CragBySlug($crag: String!) {
           height
         }
       }
+      bouldersOnly
     }
     comments {
       id

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -14,7 +14,9 @@
       >
         <div fxFlex="12px"></div>
         <div fxFlex>Ime</div>
-        <div fxFlex="80px" fxFlex.lt-md>Dolžina</div>
+        <div *ngIf="!sector.bouldersOnly" fxFlex="80px" fxFlex.lt-md>
+          Dolžina
+        </div>
         <div fxFlex="0 1 80px">Težavnost</div>
         <div fxFlex="160px"></div>
       </div>
@@ -43,7 +45,16 @@
             >{{ route.name }}</a
           >
         </div>
-        <div fxFlex="80px" fxFlex.lt-md fxHide.lt-md>{{ route.length }} m</div>
+        <div
+          *ngIf="!sector.bouldersOnly"
+          fxFlex="80px"
+          fxFlex.lt-md
+          fxHide.lt-md
+        >
+          <ng-container *ngIf="route.routeType.id !== 'boulder'"
+            >{{ route.length }} m</ng-container
+          >
+        </div>
         <div
           fxFlex="0 1 80px"
           (mouseenter)="displayRouteGrades(route)"


### PR DESCRIPTION
For sectors that have only boulders, do not display height column at all. 
For mixed sectors, just do not display height in the boulder row.

To test this:
First pull BE branch with same name.
Open for example PCL crag which has both boulders and sport routes to see the sector without height column.
Then change routeTypeId of some routes in db to get a 'mixed' sector.