### PR TITLE
Fix cache bug on clubs.

### DIFF
--- a/src/app/forms/club-member-form/club-member-form.component.ts
+++ b/src/app/forms/club-member-form/club-member-form.component.ts
@@ -40,10 +40,15 @@ export class ClubMemberFormComponent implements OnInit {
           },
         },
         {
-          errorPolicy: 'all',
           update: (cache) => {
             cache.evict({
               id: cache.identify(this.data.club),
+            });
+
+            // remove from cache all queries on activityRoutes for club members - will need to fetch again because we have a new member
+            cache.evict({
+              id: 'ROOT_QUERY',
+              fieldName: 'activityRoutesByClubSlug',
             });
           },
         }

--- a/src/app/pages/club/club-activity-routes/club-activity-routes.component.ts
+++ b/src/app/pages/club/club-activity-routes/club-activity-routes.component.ts
@@ -31,8 +31,6 @@ export class ClubActivityRoutesComponent implements OnInit, OnDestroy {
 
   activityRoutesQuery: QueryRef<any>;
 
-  // activityRoutes: ActivityRoutesByClubQuery['activityRoutesByClub']['items'];
-  // pagination: ActivityRoutesByClubQuery['activityRoutesByClub']['meta'];
   activityRoutes: ActivityRoutesByClubSlugQuery['activityRoutesByClubSlug']['items'];
   pagination: ActivityRoutesByClubSlugQuery['activityRoutesByClubSlug']['meta'];
 
@@ -95,6 +93,7 @@ export class ClubActivityRoutesComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     const clubSlug = this.activatedRoute.snapshot.parent.params.club;
 
+    // A new member can also be added on club-activity-routes page
     this.memberAddedSubscription = this.clubService.memberAdded$.subscribe(
       () => {
         this.activityRoutesQuery.refetch();

--- a/src/app/pages/club/club-members/club-members.component.ts
+++ b/src/app/pages/club/club-members/club-members.component.ts
@@ -49,12 +49,18 @@ export class ClubMembersComponent implements OnInit {
           return this.deleteClubMemberGQL.mutate(
             { id },
             {
-              errorPolicy: 'all',
-              refetchQueries: [namedOperations.Query.ClubBySlug],
+              refetchQueries: [namedOperations.Query.ClubBySlug], // list of members on club members view will change
               update: (cache) => {
+                // on myClubs view number of members will change
                 cache.evict({
                   id: 'ROOT_QUERY',
                   fieldName: 'myClubs',
+                });
+
+                // remove from cache all queries on activityRoutes for club members - will need to fetch again because we lost a member
+                cache.evict({
+                  id: 'ROOT_QUERY',
+                  fieldName: 'activityRoutesByClubSlug',
                 });
               },
             }


### PR DESCRIPTION
Test this by identifying the bug on master first, which is:
Go to clubs, club, activity routes tab.
Go back to members tab.
Add or remove a member. 
Go back to activity-routes tab. 
Activity-routes list should have updated by removing ars of the deleted member or adding ars of the added member, but doesn't 

Switch to this branch and try again. Should work now.
