### PR TITLE
Remove custom route in activity

### DIFF
--- a/src/app/forms/activity-form/activity-form.component.html
+++ b/src/app/forms/activity-form/activity-form.component.html
@@ -54,12 +54,7 @@
       </div>
     </div>
   </div>
-  <div fxFlex>
-    <div fxFlex>
-      <button type="button" mat-button (click)="add()" [disabled]="loading">
-        Dodaj smer
-      </button>
-    </div>
+  <div fxLayout="row" fxFlexAlign="end">
     <div *ngIf="!loading">
       <button
         type="button"

--- a/src/app/forms/activity-form/activity-form.component.scss
+++ b/src/app/forms/activity-form/activity-form.component.scss
@@ -4,6 +4,7 @@ form {
   max-width: 100%;
   width: 800px;
 }
+
 .route {
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   padding-bottom: 12px;
@@ -11,21 +12,7 @@ form {
     border-bottom: none;
   }
 }
-.mat-dialog-title {
-  font-size: 15px;
-  margin: -12px 0 12px 0;
-  .title {
-    color: $primary;
-  }
-}
-.mat-dialog-content {
-  box-shadow: inset 0 2px 6px 0 #6494ff26;
-  padding: 18px 24px;
-  position: relative;
-  max-height: 75vh;
-}
-.mat-dialog-actions {
-  box-shadow: 0 -2px 6px 0 #6494ff26;
-  margin: 0 -24px -24px -24px;
-  padding: 0 24px;
+
+button {
+  margin-left: 8px;
 }

--- a/src/app/forms/activity-form/activity-form.component.ts
+++ b/src/app/forms/activity-form/activity-form.component.ts
@@ -112,11 +112,6 @@ export class ActivityFormComponent implements OnInit {
     this.routes.controls[routeIndex] = temp;
   }
 
-  add(): boolean {
-    this.addRoute({});
-    return false;
-  }
-
   save(): void {
     const data = this.activityForm.value;
 

--- a/src/app/forms/activity-form/activity-form.component.ts
+++ b/src/app/forms/activity-form/activity-form.component.ts
@@ -143,8 +143,7 @@ export class ActivityFormComponent implements OnInit {
         stars: route.stars,
         publish: route.publish,
         votedDifficulty: route.votedDifficulty,
-        name: route.name, // TODO: do we need this?
-        position: i, // TODO: why do we need this?
+        position: i, // position of the route within the same day of ones log
       };
     });
 

--- a/src/app/forms/activity-form/activity-form.component.ts
+++ b/src/app/forms/activity-form/activity-form.component.ts
@@ -138,7 +138,7 @@ export class ActivityFormComponent implements OnInit {
         stars: route.stars,
         publish: route.publish,
         votedDifficulty: route.votedDifficulty,
-        position: i, // position of the route within the same day of ones log
+        position: i, // position of the route within the same activity of ones log
       };
     });
 


### PR DESCRIPTION
When logging routes one could log a route with custom name. 
Removed this option now. 

Test by trying to log a custom route, which is not possible anymore. :)

closes #107 