### PR TITLE
Empty route list on log form

### DIFF
--- a/src/app/forms/activity-form/activity-form.component.ts
+++ b/src/app/forms/activity-form/activity-form.component.ts
@@ -161,10 +161,19 @@ export class ActivityFormComponent implements OnInit {
       .subscribe({
         next: () => {
           this.localStorageService.removeItem('activity-selection');
-          this.snackBar.open('Vnos je bil shranjen v plezalni dnevnik', null, {
-            duration: 3000,
-          });
-          this.router.navigate(['/plezalni-dnevnik']);
+          this.snackBar
+            .open('Vnos je bil shranjen v plezalni dnevnik', 'Na dnevnik', {
+              duration: 3000,
+            })
+            .onAction()
+            .subscribe(() => {
+              this.router.navigate(['/plezalni-dnevnik']);
+            });
+          this.router.navigate([
+            '/plezalisca/',
+            this.crag.country.slug,
+            this.crag.slug,
+          ]);
         },
         error: () => {
           this.loading = false;

--- a/src/app/pages/activity/activity-input/activity-input.component.html
+++ b/src/app/pages/activity/activity-input/activity-input.component.html
@@ -1,6 +1,11 @@
-<div class="container mt-16">
-  <mat-card>
-    <mat-card-title>Vpis v plezalni dnevnik</mat-card-title>
+<div class="white-back mt-16">
+  <div class="container py-8">
+    <h1>Vpis v plezalni dnevnik</h1>
+  </div>
+</div>
+
+<ng-container *ngIf="routes.length">
+  <mat-card class="container mt-16">
     <mat-card-content>
       <app-activity-form
         [crag]="crag"
@@ -8,4 +13,16 @@
       ></app-activity-form>
     </mat-card-content>
   </mat-card>
-</div>
+</ng-container>
+
+<ng-container *ngIf="!routes.length">
+  <div class="container mt-16">
+    Izgleda, da nimaš izbranih smeri za vpis v dnevnik.
+    <br />
+    <br />
+    Vrni se <a [routerLink]="['/']">domov</a>, na
+    <a [routerLink]="['/plezalni-dnevnik']">plezalni dnevnik</a> ali na
+    <a [routerLink]="['/plezalisca/slovenija', { type: 'sport' }]">plezališča</a
+    >.
+  </div>
+</ng-container>

--- a/src/app/pages/activity/activity-input/activity-input.component.ts
+++ b/src/app/pages/activity/activity-input/activity-input.component.ts
@@ -34,7 +34,6 @@ export class ActivityInputComponent implements OnInit {
       },
       {
         name: 'Vpis',
-        path: '/plezalni-dnevnik/vpis',
       },
     ]);
   }


### PR DESCRIPTION
After submitting a log, user can navigate back via back button.
But there are no routes to log in local storage anymore.
Displays message.

test> Log a route. Click browser back button.

closes #105 
closes #122 