### PR TITLE
Fix orientation overflowing

### DIFF
--- a/src/app/pages/crags/crags.component.html
+++ b/src/app/pages/crags/crags.component.html
@@ -71,31 +71,33 @@
         <div
           fxLayout="row"
           fxLayoutAlign="start center"
+          fxLayoutGap="8px"
           fxHide.lt-md
           class="row header"
         >
-          <div fxFlex="50" fxFlex.lt-md="100">Plezališče</div>
-          <div fxFlex="25" fxFlex.lt-md>Število smeri</div>
-          <div fxFlex="20px" fxFlex.lt-md>U</div>
-          <div fxFlex="25" class="routes" fxFlex.lt-md>Težavnost</div>
+          <div fxFlex="40" fxFlex.lt-md="100">Plezališče</div>
+          <div fxFlex="20" fxFlex.lt-md>Število smeri</div>
+          <div fxFlex="20" fxFlex.lt-md>Usmerjenost</div>
+          <div fxFlex="20" class="routes" fxFlex.lt-md>Težavnost</div>
         </div>
         <div
           *ngFor="let crag of filteredCrags"
           [routerLink]="['/plezalisca/', country.slug, crag.slug]"
           fxLayout="row"
           fxLayoutAlign="start center"
+          fxLayoutGap="8px"
           class="row"
         >
-          <div fxFlex="50" fxFlex.lt-md="100">
+          <div fxFlex="40" fxFlex.lt-md="100">
             <a [routerLink]="['/plezalisca/', country.slug, crag.slug]">{{
               crag.name
             }}</a>
           </div>
-          <div fxFlex="25" fxFlex.lt-md fxHide.lt-md>{{ crag.nrRoutes }}</div>
-          <div fxFlex="20px" fxFlex.lt-md fxHide.lt-md>
+          <div fxFlex="20" fxFlex.lt-md fxHide.lt-md>{{ crag.nrRoutes }}</div>
+          <div fxFlex="20" fxFlex.lt-md fxHide.lt-md>
             {{ crag.orientation | orientation }}
           </div>
-          <div fxFlex="25" fxFlex.lt-md class="routes">
+          <div fxFlex="20" fxFlex.lt-md class="routes">
             <span fxHide.gt-sm>{{ crag.nrRoutes }} smeri<br /></span>
             <app-grade
               [difficulty]="crag.minDifficulty"

--- a/src/app/shared/pipes/orientation.pipe.ts
+++ b/src/app/shared/pipes/orientation.pipe.ts
@@ -4,12 +4,12 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'orientation',
 })
 export class OrientationPipe implements PipeTransform {
-  transform(value: string): string {
+  transform(value: string, display = 'full'): string {
     const sides = {
-      N: 'sever',
-      S: 'jug',
-      E: 'vzhod',
-      W: 'zahod',
+      N: { full: 'sever', short: 'S' },
+      S: { full: 'jug', short: 'J' },
+      E: { full: 'vzhod', short: 'V' },
+      W: { full: 'zahod', short: 'Z' },
     };
 
     if (value == null) {
@@ -17,15 +17,19 @@ export class OrientationPipe implements PipeTransform {
     }
 
     if (value.length == 1) {
-      return sides[value] || '';
+      return sides[value][display] || '';
     }
 
     if (
       value.length == 2 &&
-      sides[value[0]] != null &&
-      sides[value[1]] != null
+      sides[value[0]][display] != null &&
+      sides[value[1]][display] != null
     ) {
-      return sides[value[0]] + 'o' + sides[value[1]];
+      return (
+        sides[value[0]][display] +
+        (display === 'full' ? 'o' : '') +
+        sides[value[1]][display]
+      );
     }
 
     return '';


### PR DESCRIPTION
Fixed layout on crags list view to accommodate enough space for orientation strings.

Also modified orientation pipe to accept a parameter. It was not used in the end for this issue, but might come in handy later, so left it anyway...

test this by going to crags list page and narrowing the browser window and observing the layout.

closes #139 