### PR TITLE
Filtered table sort fix

### DIFF
--- a/src/app/common/filtered-table.ts
+++ b/src/app/common/filtered-table.ts
@@ -31,6 +31,8 @@ export class FilteredTable {
 
   sortColumn: string;
   sortDirection: string;
+  defaultSortColumn: string;
+  defaultSortDirection: string;
 
   constructor(columns: ColumnDefinition[], filters: FilterDefinition[]) {
     this.columns = columns.map((column) => {
@@ -43,8 +45,8 @@ export class FilteredTable {
     const sortCol = this.columns.find((col) => col.defaultSort != null);
 
     if (sortCol) {
-      this.sortColumn = sortCol.name;
-      this.sortDirection = sortCol.defaultSort;
+      this.defaultSortColumn = this.sortColumn = sortCol.name;
+      this.defaultSortDirection = this.sortDirection = sortCol.defaultSort;
     }
 
     this.filters = filters;
@@ -80,15 +82,28 @@ export class FilteredTable {
     }
 
     if (values.sort != null) {
+      // sort field was passed, use it to sort
       const sortCol = values.sort.split(',');
       this.sortColumn = sortCol[0];
       this.sortDirection = sortCol[1];
+    } else {
+      // sort field was not passed, but we might have a default sort set
+      if (this.defaultSortColumn && this.defaultSortDirection) {
+        // use default sort that was set in filteredTable constructor
+        this.sortColumn = this.defaultSortColumn;
+        this.sortDirection = this.defaultSortDirection;
+      } else {
+        // we dont't have a default sort, so unset the sort
+        this.sortColumn = this.sortDirection = null;
+      }
     }
 
-    qp.orderBy = {
-      field: this.sortColumn,
-      direction: this.sortDirection,
-    };
+    if (this.sortColumn && this.sortDirection) {
+      qp.orderBy = {
+        field: this.sortColumn,
+        direction: this.sortDirection,
+      };
+    }
 
     this.setFilterParams(fp, false);
 

--- a/src/app/management/pages/crag/crag.component.ts
+++ b/src/app/management/pages/crag/crag.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { param } from 'jquery';
 import { filter, of, Subscription, switchMap, take } from 'rxjs';
 import { LayoutService } from 'src/app/services/layout.service';
 import {

--- a/src/app/pages/activity/activity-routes/activity-routes.component.html
+++ b/src/app/pages/activity/activity-routes/activity-routes.component.html
@@ -1,131 +1,144 @@
-<app-activity-header active="vzponi"></app-activity-header>
+<app-data-error *ngIf="error" [error]="error"></app-data-error>
 
-<div class="container mt-16">
-  <div fxLayout="row" [formGroup]="filters" fxLayoutGap="8px">
-    <mat-form-field appearance="fill">
-      <mat-label>Časovno obdobje</mat-label>
-      <mat-date-range-input [rangePicker]="picker">
-        <input
-          matStartDate
-          formControlName="dateFrom"
-          placeholder="Start date"
-        />
-        <input matEndDate formControlName="dateTo" placeholder="End date" />
-      </mat-date-range-input>
-      <div matSuffix fxLayout="row">
+<ng-container *ngIf="!error">
+  <app-activity-header active="vzponi"></app-activity-header>
+
+  <div class="container mt-16">
+    <div fxLayout="row" [formGroup]="filters" fxLayoutGap="8px">
+      <mat-form-field appearance="fill">
+        <mat-label>Časovno obdobje</mat-label>
+        <mat-date-range-input [rangePicker]="picker">
+          <input
+            matStartDate
+            formControlName="dateFrom"
+            placeholder="Start date"
+          />
+          <input matEndDate formControlName="dateTo" placeholder="End date" />
+        </mat-date-range-input>
+        <div matSuffix fxLayout="row">
+          <button
+            mat-icon-button
+            matSuffix
+            *ngIf="
+              filters.value.dateFrom != null || filters.value.dateTo != null
+            "
+            (click)="filters.patchValue({ dateFrom: null, dateTo: null })"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+          <mat-datepicker-toggle
+            matSuffix
+            [for]="picker"
+          ></mat-datepicker-toggle>
+        </div>
+
+        <mat-date-range-picker #picker></mat-date-range-picker>
+
+        <mat-error
+          *ngIf="filters.controls.dateFrom.hasError('matStartDateInvalid')"
+          >Neveljaven začetni datum</mat-error
+        >
+        <mat-error *ngIf="filters.controls.dateTo.hasError('matEndDateInvalid')"
+          >Neveljaven končni datum</mat-error
+        >
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Vrsta vzpona</mat-label>
+        <mat-select formControlName="ascentType" multiple>
+          <mat-option *ngFor="let type of ascentTypes" [value]="type.value"
+            >{{ type.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field>
+        <mat-label>Objava</mat-label>
+        <mat-select formControlName="publish" multiple>
+          <mat-option
+            *ngFor="let option of publishOptions"
+            [value]="option.value"
+            >{{ option.label }}
+          </mat-option>
+        </mat-select>
+      </mat-form-field>
+
+      <mat-form-field *ngIf="forCrag">
+        <mat-label>Plezališče</mat-label>
+        <input matInput disabled [value]="forCrag.name" />
         <button
           mat-icon-button
           matSuffix
-          *ngIf="filters.value.dateFrom != null || filters.value.dateTo != null"
-          (click)="filters.patchValue({ dateFrom: null, dateTo: null })"
+          (click)="filters.patchValue({ cragId: null })"
         >
           <mat-icon>close</mat-icon>
         </button>
-        <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
-      </div>
+      </mat-form-field>
 
-      <mat-date-range-picker #picker></mat-date-range-picker>
-
-      <mat-error
-        *ngIf="filters.controls.dateFrom.hasError('matStartDateInvalid')"
-        >Neveljaven začetni datum</mat-error
-      >
-      <mat-error *ngIf="filters.controls.dateTo.hasError('matEndDateInvalid')"
-        >Neveljaven končni datum</mat-error
-      >
-    </mat-form-field>
-
-    <mat-form-field>
-      <mat-label>Vrsta vzpona</mat-label>
-      <mat-select formControlName="ascentType" multiple>
-        <mat-option *ngFor="let type of ascentTypes" [value]="type.value"
-          >{{ type.label }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field>
-      <mat-label>Objava</mat-label>
-      <mat-select formControlName="publish" multiple>
-        <mat-option *ngFor="let option of publishOptions" [value]="option.value"
-          >{{ option.label }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field *ngIf="forCrag">
-      <mat-label>Plezališče</mat-label>
-      <input matInput disabled [value]="forCrag.name" />
-      <button
-        mat-icon-button
-        matSuffix
-        (click)="filters.patchValue({ cragId: null })"
-      >
-        <mat-icon>close</mat-icon>
-      </button>
-    </mat-form-field>
-
-    <mat-form-field *ngIf="forRoute">
-      <mat-label>Smer</mat-label>
-      <input matInput disabled [value]="forRoute.name" />
-      <button
-        mat-icon-button
-        matSuffix
-        (click)="filters.patchValue({ routeId: null })"
-      >
-        <mat-icon>close</mat-icon>
-      </button>
-    </mat-form-field>
-  </div>
-
-  <app-data-error *ngIf="error" [error]="error"></app-data-error>
-
-  <div class="card has-loader" *ngIf="!error">
-    <div class="card-loader" *ngIf="loading">
-      <app-loader></app-loader>
+      <mat-form-field *ngIf="forRoute">
+        <mat-label>Smer</mat-label>
+        <input matInput disabled [value]="forRoute.name" />
+        <button
+          mat-icon-button
+          matSuffix
+          (click)="filters.patchValue({ routeId: null })"
+        >
+          <mat-icon>close</mat-icon>
+        </button>
+      </mat-form-field>
     </div>
-    <table class="card-table">
-      <tr class="row header">
-        <td *ngFor="let column of filteredTable.columns">
-          <span
-            *ngIf="column.sortable"
-            class="sortable"
-            [class.sorted]="filteredTable.sortColumn == column.name"
-            (click)="filteredTable.sort(column)"
-          >
-            {{ column.label }}
-            <mat-icon inline *ngIf="filteredTable.sortColumn != column.name"
-              >sort</mat-icon
+
+    <div class="card has-loader">
+      <div class="card-loader" *ngIf="loading">
+        <app-loader></app-loader>
+      </div>
+      <table class="card-table">
+        <tr class="row header">
+          <td *ngFor="let column of filteredTable.columns">
+            <span
+              *ngIf="column.sortable"
+              class="sortable"
+              [class.sorted]="filteredTable.sortColumn == column.name"
+              (click)="filteredTable.sort(column)"
             >
-            <mat-icon inline *ngIf="filteredTable.sortColumn == column.name">{{
-              filteredTable.sortDirection == "DESC"
-                ? "arrow_downward"
-                : "arrow_upward"
-            }}</mat-icon>
-          </span>
-          <span *ngIf="!column.sortable">{{ column.label }}</span>
-        </td>
-        <td></td>
-      </tr>
+              {{ column.label }}
+              <mat-icon inline *ngIf="filteredTable.sortColumn != column.name"
+                >sort</mat-icon
+              >
+              <mat-icon
+                inline
+                *ngIf="filteredTable.sortColumn == column.name"
+                >{{
+                  filteredTable.sortDirection == "DESC"
+                    ? "arrow_downward"
+                    : "arrow_upward"
+                }}</mat-icon
+              >
+            </span>
+            <span *ngIf="!column.sortable">{{ column.label }}</span>
+          </td>
+          <td></td>
+        </tr>
 
-      <tr
-        class="row"
-        *ngFor="let route of routes"
-        app-activity-route-row
-        [route]="route"
-        [rowAction]="rowAction$"
-      ></tr>
-    </table>
+        <tr
+          class="row"
+          *ngFor="let route of routes"
+          app-activity-route-row
+          [route]="route"
+          [rowAction]="rowAction$"
+        ></tr>
+      </table>
+    </div>
+
+    <mat-paginator
+      *ngIf="pagination != null"
+      hidePageSize
+      showFirstLastButtons
+      [length]="pagination.itemCount"
+      [pageIndex]="pagination.pageNumber - 1"
+      [pageSize]="pagination.pageSize"
+      (page)="filteredTable.paginate($event)"
+    >
+    </mat-paginator>
   </div>
-
-  <mat-paginator
-    *ngIf="pagination != null"
-    hidePageSize
-    showFirstLastButtons
-    [length]="pagination.itemCount"
-    [pageIndex]="pagination.pageNumber - 1"
-    [pageSize]="pagination.pageSize"
-    (page)="filteredTable.paginate($event)"
-  >
-  </mat-paginator>
-</div>
+</ng-container>

--- a/src/app/pages/club/club-activity-routes/club-activity-routes.component.ts
+++ b/src/app/pages/club/club-activity-routes/club-activity-routes.component.ts
@@ -18,8 +18,6 @@ import {
 } from 'src/generated/graphql';
 import { ClubService } from '../club.service';
 
-// TODO: keep scroll position when paginating? what is the expected behaviour?
-
 @Component({
   selector: 'app-club-activity-routes',
   templateUrl: './club-activity-routes.component.html',
@@ -146,7 +144,7 @@ export class ClubActivityRoutesComponent implements OnInit, OnDestroy {
 
     this.filtersSubscription = this.filters.valueChanges
       .pipe(
-        filter((_) => {
+        filter(() => {
           return !this.ignoreFormChange; // date picker ignores emitEvent:false. This is a workaround
         }),
         debounceTime(100) // datepicker triggers 4 valueChanges events. this is a workaround


### PR DESCRIPTION
Fixes problem on sort when back button was pressed.
Also takes into account that a filtered table might not have a default sort column set at all.
Also removes nested subscription in activity-routes component.
Also slightly changes error display on log.

To test this go to log and display logged routes. Sort the table by grade for example, then press back in browser and see that the sort goes back to default and does not fail. 
Can do the same test on club logs.

closes #169 
