### PR TITLE
Fix bug where comment author was missing in route preview

### DIFF
--- a/src/app/graphql/routes/route-comments.query.graphql
+++ b/src/app/graphql/routes/route-comments.query.graphql
@@ -4,8 +4,7 @@ query RouteComments($routeId: String!) {
       id
       type
       user {
-        firstname
-        lastname
+        fullName
       }
       content
       updated


### PR DESCRIPTION
The `<app-comment>` component that is used in different places is expecting the user object to have a `fullName` property. The query used by the route preview component provided `firstname` and `lastname` but not the `fullName`.

Before:
<img width="758" alt="image" src="https://user-images.githubusercontent.com/6022408/154848064-a76bcaca-6785-483d-8db2-9be134378c79.png">


After:
<img width="778" alt="image" src="https://user-images.githubusercontent.com/6022408/154847948-ea9f44b1-f4ce-46b1-b1b3-7894f89a6d71.png">
