### PR TITLE
Search no comments in autocomplete

### DIFF
--- a/src/app/pages/home/latest-images/latest-image.query.graphql
+++ b/src/app/pages/home/latest-images/latest-image.query.graphql
@@ -1,14 +1,18 @@
 query LatestImages($latest: Int!) {
   latestImages(latest: $latest) {
+    id
     path
     title
     user {
+      id
       fullName
     }
     crag {
+      id
       name
       slug
       country {
+        id
         slug
       }
     }
@@ -17,9 +21,11 @@ query LatestImages($latest: Int!) {
       name
       slug
       crag {
+        id
         name
         slug
         country {
+          id
           slug
         }
       }

--- a/src/app/pages/home/popular-crags/popular-crags.query.graphql
+++ b/src/app/pages/home/popular-crags/popular-crags.query.graphql
@@ -2,9 +2,11 @@ query PopularCrags($dateFrom: String, $top: Int) {
   popularCrags(dateFrom: $dateFrom, top: $top) {
     nrVisits
     crag {
+      id
       name
       slug
       country {
+        id
         slug
       }
     }

--- a/src/app/pages/search/search-results/search.query.graphql
+++ b/src/app/pages/search/search-results/search.query.graphql
@@ -2,6 +2,7 @@ query Search($query: String) {
   search(input: $query) {
     crags {
       __typename
+      id
       name
       slug
       nrRoutes
@@ -12,6 +13,7 @@ query Search($query: String) {
         id
       }
       country {
+        id
         slug
       }
     }
@@ -27,6 +29,7 @@ query Search($query: String) {
       isProject
       length
       crag {
+        id
         name
         slug
         country {
@@ -36,22 +39,28 @@ query Search($query: String) {
     }
     sectors {
       __typename
+      id
       name
       crag {
+        id
         name
         slug
         country {
+          id
           slug
         }
       }
     }
     comments {
       __typename
+      id
       content
       crag {
+        id
         name
         slug
         country {
+          id
           slug
         }
       }
@@ -61,20 +70,24 @@ query Search($query: String) {
         slug
         name
         crag {
+          id
           name
           slug
           country {
+            id
             slug
           }
         }
       }
       user {
+        id
         fullName
       }
       created
     }
     users {
       __typename
+      id
       fullName
     }
   }

--- a/src/app/pages/search/search-results/search.query.graphql
+++ b/src/app/pages/search/search-results/search.query.graphql
@@ -33,6 +33,7 @@ query Search($query: String) {
         name
         slug
         country {
+          id
           slug
         }
       }

--- a/src/app/pages/search/search.component.html
+++ b/src/app/pages/search/search.component.html
@@ -54,18 +54,6 @@
               {{ user.fullName }}
             </mat-option>
           </mat-optgroup>
-
-          <mat-optgroup
-            *ngIf="searchResults?.comments.length"
-            label="Komentarji"
-          >
-            <mat-option
-              *ngFor="let comment of searchResults.comments"
-              [value]="comment"
-            >
-              {{ truncateComment(comment.content) }}
-            </mat-option>
-          </mat-optgroup>
         </ng-container>
       </mat-autocomplete>
       <button

--- a/src/app/pages/search/searchAutoComplete.query.graphql
+++ b/src/app/pages/search/searchAutoComplete.query.graphql
@@ -1,0 +1,37 @@
+query SearchAutoComplete($searchString: String) {
+  search(input: $searchString) {
+    crags {
+      __typename
+      id
+      name
+      slug
+    }
+
+    routes {
+      __typename
+      id
+      slug
+      name
+      crag {
+        id
+        slug
+      }
+    }
+
+    sectors {
+      __typename
+      id
+      name
+      crag {
+        id
+        slug
+      }
+    }
+
+    users {
+      __typename
+      id
+      fullName
+    }
+  }
+}


### PR DESCRIPTION
When searching now all entities except comments are searched within the autocomplete. If search string is confirmed the search results page is still displayed and all entities (including comments) are searched.

To test try searching for a term that should appear in comments and see that autocomplete does not display results of type comments. Confirm search and see that comments are then still searched and shown on results page.

closes #187 