### PR TITLE
Comments on route fix

### DIFF
--- a/src/app/pages/route/route-comments/route-comments.component.html
+++ b/src/app/pages/route/route-comments/route-comments.component.html
@@ -28,7 +28,7 @@
   >
     <app-comment [comment]="comment"></app-comment>
   </div>
-  <div *ngIf="!regularComments.length && !previewMode">
+  <div *ngIf="!regularComments.length && !previewMode" class="p-16">
     Ta smer nima še nobenega komentarja.
   </div>
 
@@ -38,7 +38,11 @@
     fxLayoutAlign="center center"
     fxLayout.lt-md="column"
   >
-    <span fxFlex="100">Opisi razmer</span>
+    <span fxFlex="100"
+      ><ng-container *ngIf="conditions.length > 0"
+        >Opisi razmer</ng-container
+      ></span
+    >
     <div fxFlex>
       <button mat-button color="primary" (click)="addComment('add-condition')">
         Dodaj opis razmer
@@ -53,9 +57,6 @@
   >
     <app-comment [comment]="conditionComment"></app-comment>
   </div>
-  <div *ngIf="!conditions.length && !previewMode">
-    Ta smer nima še nobenega opisa razmer.
-  </div>
 
   <h3
     *ngIf="!previewMode"
@@ -63,7 +64,11 @@
     fxLayoutAlign="center center"
     fxLayout.lt-md="column"
   >
-    <span fxFlex="100">Opisi smeri</span>
+    <span fxFlex="100"
+      ><ng-container *ngIf="descriptions.length > 0"
+        >Opisi smeri</ng-container
+      ></span
+    >
     <div fxFlex>
       <button
         mat-button
@@ -81,8 +86,5 @@
     fxLayoutGap="8px"
   >
     <app-comment [comment]="description"></app-comment>
-  </div>
-  <div *ngIf="!descriptions.length && !previewMode">
-    Ta smer nima še nobenega opisa.
   </div>
 </div>

--- a/src/app/pages/route/route-comments/route-comments.component.html
+++ b/src/app/pages/route/route-comments/route-comments.component.html
@@ -1,55 +1,88 @@
 <div #container>
-  <h3 *ngIf="regularComments.length"
-      fxLayout="row"
-      fxLayoutAlign="center center"
-      fxLayout.lt-md="column">
-    <span fxFlex="100">{{ previewMode ? 'Najnovejši komentarji' : 'Komentarji' }}</span>
+  <h3
+    *ngIf="!previewMode || regularComments.length"
+    fxLayout="row"
+    fxLayoutAlign="center center"
+    fxLayout.lt-md="column"
+  >
+    <span fxFlex="100">{{
+      previewMode ? "Najnovejši komentarji" : "Komentarji"
+    }}</span>
     <div fxFlex>
-      <button *ngIf="!previewMode"
-              mat-button
-              color="primary">Dodaj komentar</button>
+      <button
+        *ngIf="!previewMode"
+        (click)="addComment('add-comment')"
+        mat-button
+        color="primary"
+      >
+        Dodaj komentar
+      </button>
     </div>
   </h3>
-  <div *ngFor="let comment of regularComments | slice:0: previewMode ? 3 : 1000"
-       class="comment"
-       fxLayout="column"
-       fxLayoutGap="8px">
+
+  <div
+    *ngFor="let comment of regularComments | slice: 0:(previewMode ? 3 : 1000)"
+    class="comment"
+    fxLayout="column"
+    fxLayoutGap="8px"
+  >
     <app-comment [comment]="comment"></app-comment>
   </div>
+  <div *ngIf="!regularComments.length && !previewMode">
+    Ta smer nima še nobenega komentarja.
+  </div>
 
-  <ng-container *ngIf="!previewMode">
-    <h3 *ngIf="conditions.length"
-        fxLayout="row"
-        fxLayoutAlign="center center"
-        fxLayout.lt-md="column">
-      <span fxFlex="100">Opisi razmer</span>
-      <div fxFlex>
-        <button mat-button
-                color="primary">Dodaj opis razmer</button>
-      </div>
-    </h3>
-    <div *ngFor="let conditionComment of conditions"
-        class="comment"
-        fxLayout="column"
-        fxLayoutGap="8px">
-      <app-comment [comment]="conditionComment"></app-comment>
+  <h3
+    *ngIf="!previewMode"
+    fxLayout="row"
+    fxLayoutAlign="center center"
+    fxLayout.lt-md="column"
+  >
+    <span fxFlex="100">Opisi razmer</span>
+    <div fxFlex>
+      <button mat-button color="primary" (click)="addComment('add-condition')">
+        Dodaj opis razmer
+      </button>
     </div>
+  </h3>
+  <div
+    *ngFor="let conditionComment of conditions"
+    class="comment"
+    fxLayout="column"
+    fxLayoutGap="8px"
+  >
+    <app-comment [comment]="conditionComment"></app-comment>
+  </div>
+  <div *ngIf="!conditions.length && !previewMode">
+    Ta smer nima še nobenega opisa razmer.
+  </div>
 
-    <h3 *ngIf="descriptions.length"
-        fxLayout="row"
-        fxLayoutAlign="center center"
-        fxLayout.lt-md="column">
-      <span fxFlex="100">Opisi smeri</span>
-      <div fxFlex>
-        <button mat-button
-                color="primary">Dodaj opis smeri</button>
-      </div>
-    </h3>
-    <div *ngFor="let description of descriptions"
-        class="comment"
-        fxLayout="column"
-        fxLayoutGap="8px">
-      <app-comment [comment]="description"></app-comment>
+  <h3
+    *ngIf="!previewMode"
+    fxLayout="row"
+    fxLayoutAlign="center center"
+    fxLayout.lt-md="column"
+  >
+    <span fxFlex="100">Opisi smeri</span>
+    <div fxFlex>
+      <button
+        mat-button
+        color="primary"
+        (click)="addComment('add-description')"
+      >
+        Dodaj opis smeri
+      </button>
     </div>
-  </ng-container>
+  </h3>
+  <div
+    *ngFor="let description of descriptions"
+    class="comment"
+    fxLayout="column"
+    fxLayoutGap="8px"
+  >
+    <app-comment [comment]="description"></app-comment>
+  </div>
+  <div *ngIf="!descriptions.length && !previewMode">
+    Ta smer nima še nobenega opisa.
+  </div>
 </div>

--- a/src/app/pages/route/route-comments/route-comments.component.ts
+++ b/src/app/pages/route/route-comments/route-comments.component.ts
@@ -1,4 +1,11 @@
-import { AfterViewInit, Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+} from '@angular/core';
+import { Subject } from 'rxjs';
 
 interface IComment {
   content: string;
@@ -22,6 +29,7 @@ export class RouteCommentsComponent implements AfterViewInit {
   descriptions: IComment[];
 
   @Output() onViewInit = new EventEmitter<void>();
+  @Input() action$: Subject<string>;
   @Input() previewMode: boolean = false;
   @Input() set comments(comments: IComment[]) {
     this.allComments = comments;
@@ -46,6 +54,10 @@ export class RouteCommentsComponent implements AfterViewInit {
   }
 
   constructor() {}
+
+  addComment(actionType: string) {
+    this.action$.next(actionType);
+  }
 
   ngAfterViewInit(): void {
     // this is used when this component is a child of CragRoutePreviewComponent which measures the height after view init

--- a/src/app/pages/route/route.component.html
+++ b/src/app/pages/route/route.component.html
@@ -29,8 +29,8 @@
     >
       <app-crag-gallery [images]="route.images"></app-crag-gallery>
       <app-route-comments
-        *ngIf="route.comments.length"
         [comments]="route.comments"
+        [action$]="action$"
       ></app-route-comments>
     </div>
   </div>

--- a/src/app/pages/route/route.component.ts
+++ b/src/app/pages/route/route.component.ts
@@ -3,6 +3,10 @@ import { ActivatedRoute, Params, Router } from '@angular/router';
 import { DataError } from '../../types/data-error';
 import { LayoutService } from '../../services/layout.service';
 import { RouteBySlugGQL, RouteBySlugQuery } from 'src/generated/graphql';
+import { Subject } from 'rxjs';
+import { AuthService } from 'src/app/auth/auth.service';
+import { MatDialog } from '@angular/material/dialog';
+import { CommentFormComponent } from 'src/app/shared/components/comment-form/comment-form.component';
 
 @Component({
   selector: 'app-route',
@@ -17,10 +21,14 @@ export class RouteComponent implements OnInit {
 
   section: string;
 
+  action$ = new Subject<string>();
+
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute,
     private layoutService: LayoutService,
+    private authService: AuthService,
+    private dialog: MatDialog,
     private routeBySlugGQL: RouteBySlugGQL
   ) {}
 
@@ -44,6 +52,34 @@ export class RouteComponent implements OnInit {
             this.querySuccess(result.data);
           }
         });
+    });
+
+    this.action$.subscribe((action) => {
+      switch (action) {
+        case 'add-comment':
+          this.addComment('comment');
+          break;
+        case 'add-condition':
+          this.addComment('condition');
+          break;
+        case 'add-description':
+          this.addComment('description');
+          break;
+      }
+    });
+  }
+
+  addComment(type: string) {
+    this.authService.guardedAction({}).then((success) => {
+      if (success) {
+        this.dialog.open(CommentFormComponent, {
+          data: {
+            route: this.route,
+            type,
+          },
+          autoFocus: false,
+        });
+      }
     });
   }
 

--- a/src/app/shared/components/comment-form/comment-form.component.ts
+++ b/src/app/shared/components/comment-form/comment-form.component.ts
@@ -59,18 +59,23 @@ export class CommentFormComponent implements OnInit {
       }
     }
 
-    if (this.data.type == 'warning') {
-      this.title = 'Dodaj opozorilo';
-
-      this.addExposedUntilField();
-    }
-
-    if (this.data.type == 'condition') {
-      this.title = 'Dodaj informacijo o razmerah';
-    }
-
-    if (this.data.type == 'comment') {
-      this.title = 'Dodaj komentar';
+    switch (this.data.type) {
+      case 'warning':
+        this.title = 'Dodaj opozorilo';
+        this.addExposedUntilField();
+        break;
+      case 'condition':
+        this.title = 'Dodaj informacijo o razmerah';
+        break;
+      case 'comment':
+        this.title = 'Dodaj komentar';
+        break;
+      case 'description':
+        // TODO: it seems that only peaks and routes can have comments of type description. Might want to include entity type in the title and generalize this. Should discuss.
+        this.title = 'Dodaj opis';
+        break;
+      default:
+        this.title = '';
     }
   }
 
@@ -110,8 +115,10 @@ export class CommentFormComponent implements OnInit {
         { input: value },
         {
           refetchQueries: [
+            //TODO: some of these queries might not be active and trying to refetch them causes apollo warnings
             namedOperations.Query.CragBySlug,
             namedOperations.Query.IceFallBySlug,
+            namedOperations.Query.RouteBySlug,
           ],
         }
       )


### PR DESCRIPTION
Makes 'Dodaj komentar' button on route work.
 It also displays all types of comments on route page, even if the list is empty. 

Fixes some nested subscriptions and error handling.

Test this by adding comments of different types to a route.

closes #191 