### PR TITLE
Fix auth token check

### DIFF
--- a/src/app/services/local-storage.service.ts
+++ b/src/app/services/local-storage.service.ts
@@ -9,15 +9,19 @@ export class LocalStorageService {
   constructor() {}
 
   getItem(key: string): any {
-    key = this.getKey(key);
+    const prefixedKey = this.getKey(key);
 
-    const item = JSON.parse(localStorage.getItem(key));
+    const item = JSON.parse(localStorage.getItem(prefixedKey));
 
     if (!item) {
       return;
     }
 
-    if (moment(item.expirationDate).isBefore(moment(new Date()))) {
+    // Check that the item is not expired, but only if expiration date is set. Otherwise assume that the item never expires.
+    if (
+      item.expirationDate &&
+      moment(item.expirationDate).isBefore(moment(new Date()))
+    ) {
       this.removeItem(key);
       return;
     } else {


### PR DESCRIPTION
Two bugs are fixed with this PR:

1. Auth token has no expirationDate.  LocalStorageService now expects that possibility when getting an item.

2. If a token (item) is expired then it is now properly removed. (Was being "double prefixed" before)

Test by refreshing the page multiple times while being logged in.

closes #198 