### PR TITLE
Diff votes chart fixes

### DIFF
--- a/src/app/common/distribution-chart/distribution-chart.component.html
+++ b/src/app/common/distribution-chart/distribution-chart.component.html
@@ -1,12 +1,13 @@
 <div class="distribution-container">
-  <div class="distribution-bar-wrapper"
-       *ngFor="let element of distribution">
+  <ng-container *ngFor="let element of distribution">
     <div class="distribution-bar-label">
       {{ element.label }}
     </div>
     <div class="distribution-bar">
-      <div class="distribution-bar-inner"
-           [style.width.%]="(element.value / maxValue) * 100"></div>
+      <div
+        class="distribution-bar-inner"
+        [style.width.%]="(element.value / maxValue) * 100"
+      ></div>
     </div>
-  </div>
+  </ng-container>
 </div>

--- a/src/app/common/distribution-chart/distribution-chart.component.scss
+++ b/src/app/common/distribution-chart/distribution-chart.component.scss
@@ -1,24 +1,16 @@
 .distribution-container {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: flex-start;
-}
-
-.distribution-bar-wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-gap: 0 8px;
   align-items: center;
 }
 
 .distribution-bar-label {
-  flex: 0 0 44px;
-  margin-right: 10px;
   text-align: right;
 }
 
 .distribution-bar {
   height: 8px;
-  flex: 1 1 100%;
   background-color: white;
 }
 

--- a/src/app/common/distribution-chart/distribution-chart.component.ts
+++ b/src/app/common/distribution-chart/distribution-chart.component.ts
@@ -1,4 +1,11 @@
-import { AfterViewInit, Component, EventEmitter, Input, OnChanges, Output } from '@angular/core';
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  Output,
+} from '@angular/core';
 
 export interface IDistribution {
   label: string;

--- a/src/app/pages/route/route-info/route-info.component.html
+++ b/src/app/pages/route/route-info/route-info.component.html
@@ -62,11 +62,10 @@
 <div class="card padding">
   <h4>Ocene uporabnikov</h4>
   <app-distribution-chart
+    class="difficulty-votes-chart"
     [distribution]="gradesDistribution"
-    fxFlexAlign="stretch"
   ></app-distribution-chart>
   <app-route-grades
-    fxFlexAlign="stretch"
     [grades]="grades"
     [difficulty]="route.difficulty"
     [gradingSystemId]="route.defaultGradingSystem.id"

--- a/src/app/pages/route/route-info/route-info.component.scss
+++ b/src/app/pages/route/route-info/route-info.component.scss
@@ -11,6 +11,12 @@
 .row {
   font-weight: 500;
 }
+
 .row:first-child {
   min-height: 54px;
+}
+
+.difficulty-votes-chart {
+  display: block;
+  margin-bottom: 8px;
 }


### PR DESCRIPTION
Fixes in this PR:

1. fixes misaligned bars in chart when label is long (e.g.: 6c+/7a) https://github.com/plezanje-net/web/issues/184
2. fixes distribution calculation bug where all bars were showing 100%
3. add spacing between distribution chart and difficulty votes list

All three issues are seen on these examples:

Before:
<img width="349" alt="Screenshot 2022-03-14 at 22 13 15" src="https://user-images.githubusercontent.com/6022408/158262467-cc3fd6f5-22a7-45ad-857b-83979bb595a0.png">

After:
<img width="338" alt="Screenshot 2022-03-14 at 22 12 59" src="https://user-images.githubusercontent.com/6022408/158262490-0a42fdee-8219-44d1-9600-fbfa0b978b50.png">

