### PR TITLE
Added srcset to img tags for more efficient image loading.

### DIFF
--- a/src/app/common/image-full/image-full.component.html
+++ b/src/app/common/image-full/image-full.component.html
@@ -13,7 +13,22 @@
   >
     <div fxLayout="column" class="image-w-caption-wrap">
       <img
-        [src]="storageUrl + '/images/' + data.image.path"
+        [srcset]="
+          storageUrl +
+          '/images/300/' +
+          data.image.path +
+          ' 300w, ' +
+          storageUrl +
+          '/images/600/' +
+          data.image.path +
+          ' 600w, ' +
+          storageUrl +
+          '/images/1040/' +
+          data.image.path +
+          ' 1040w'
+        "
+        sizes="100vw"
+        [src]="storageUrl + '/images/1040/' + data.image.path"
         [alt]="data.image.title"
         fxFlex="90%"
         fxLayoutAlign="center center"

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.html
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.html
@@ -1,11 +1,31 @@
 <div fxLayout="row wrap">
-  <div fxFlex="50"
-       *ngFor="let image of images"
-       class="image-container"
-       fxLayout="row"
-       fxLayoutAlign="center center">
+  <div
+    fxFlex="50"
+    *ngFor="let image of images"
+    class="image-container"
+    fxLayout="row"
+    fxLayoutAlign="center center"
+  >
     <div class="card">
-      <img [src]="storageUrl + '/images/' + image.path" (click)="onImageClick(image)" />
+      <img
+        [srcset]="
+          storageUrl +
+          '/images/300/' +
+          image.path +
+          ' 300w, ' +
+          storageUrl +
+          '/images/600/' +
+          image.path +
+          ' 600w'
+        "
+        sizes="(max-width: 599px) calc(50vw - 56.5px),
+        (max-width: 904px) calc(50vw - 72.5px),
+        (max-width: 1239px) 231.5px,
+        (max-width: 1439px) calc(33.33vw - 182px),
+        298px"
+        [src]="storageUrl + '/images/600/' + image.path"
+        (click)="onImageClick(image)"
+      />
       <div class="title">{{ image.title }}</div>
     </div>
   </div>

--- a/src/app/pages/crag/crag-image/crag-image.component.html
+++ b/src/app/pages/crag/crag-image/crag-image.component.html
@@ -1,4 +1,22 @@
 <div *ngIf="crag.images.length > 0" class="card no-border">
-  <img [src]="storageUrl + '/images/' + crag.images[0].path" [alt]="crag.images[0].title" />
+  <img
+    [srcset]=""
+    [srcset]="
+      storageUrl +
+      '/images/300/' +
+      crag.images[0].path +
+      ' 300w, ' +
+      storageUrl +
+      '/images/600/' +
+      crag.images[0].path +
+      ' 600w'
+    "
+    sizes="
+        (max-width: 1239px) 276.97px,
+        (max-width: 1439px) calc(33.33vw - 145.32px),
+        334.63px"
+    [src]="storageUrl + '/images/600/' + crag.images[0].path"
+    [alt]="crag.images[0].title"
+  />
   <!-- TODO: Should have crag-cover-image field on crag instead of simply displaying first image? -->
 </div>

--- a/src/app/pages/home/latest-images/latest-images.component.html
+++ b/src/app/pages/home/latest-images/latest-images.component.html
@@ -2,7 +2,26 @@
 <mat-grid-list [cols]="ncols" rowHeight="1:1" gutterSize="4px" *ngIf="!loading">
   <mat-grid-tile *ngFor="let image of latestImages">
     <div class="wrap" (click)="onImageClick(image)">
-      <img [src]="storageUrl + '/images/' + image.path" />
+      <!-- <img [src]="storageUrl + '/images/' + image.path" /> -->
+      <img
+        [srcset]="
+          storageUrl +
+          '/images/300/' +
+          image.path +
+          ' 300w, ' +
+          storageUrl +
+          '/images/600/' +
+          image.path +
+          ' 600w'
+        "
+        sizes="(max-width: 599px) calc(100vw - 32px),
+        (max-width: 904px) calc(50vw - 34px),
+        (max-width: 1239px) 277.33px,
+        (max-width: 1439px) calc(25vw - 103px),
+          257px"
+        [src]="storageUrl + '/images/600/' + image.path"
+      />
+
       <div class="info" fxLayout="row" fxLayoutAlign="center center">
         <div>{{ image.title }}</div>
       </div>

--- a/src/app/pages/home/latest-images/latest-images.component.ts
+++ b/src/app/pages/home/latest-images/latest-images.component.ts
@@ -57,10 +57,9 @@ export class LatestImagesComponent implements OnInit, OnDestroy {
       }
     });
 
-    
     this.subscription = this.authService.currentUser
-    .pipe(
-      switchMap((user) => {
+      .pipe(
+        switchMap((user) => {
           this.loadingSpinnerService.pushLoader();
           return this.latestImagesGQL.fetch({ latest: 12 });
         })

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -7,6 +7,7 @@ export const environment = {
   apiUrl: 'http://localhost:3000/graphql',
   webUrl: 'http://localhost:4200/',
   storageUrl: 'https://plezanje.info/storage',
+  // storageUrl: 'assets', // TODO: this is a test
   storageKeyPrefix: 'plezanje-local-1',
 };
 


### PR DESCRIPTION
Using srcset for images, so that the browser can choose correct size based on current screen size. 
keeping src as a fallback.

see image sizes gdrive doc for size calc explanations.
This will of course change when we change the layout. 
Additional sizes of images will probably need to be added based on FE needs.

could probably convert img with srcset to a component to make code cleaner -> another task
could add webp format as default and jpeg as a fallback -> another task

(Some images might not load yet because they have not been uploaded to the server yet... doing this in meantime...)

To test this open network tab in dev tools, resize window so that only a small image is needed. reload page. see that the small image is fetched. resize window so that the image gets bigger. see that the browser fetches other sizes when needed. (don't forget to disable cache in dev tools)



