### PR TITLE
Add image upload component and use it in crag gallery

### DIFF
--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.html
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.html
@@ -1,3 +1,9 @@
+<h3 fxLayout="row" fxLayoutAlign="center center" fxLayout.lt-md="column">
+  <span fxFlex="100">Slike uporabnikov</span>
+  <button mat-button color="primary" (click)="onAddImagesClick()">
+    Dodaj slike
+  </button>
+</h3>
 <div fxLayout="row wrap">
   <div
     fxFlex="50"

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.ts
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.ts
@@ -1,21 +1,22 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { environment } from 'src/environments/environment';
 import { ImageFullComponent } from 'src/app/common/image-full/image-full.component';
+import { AuthService } from 'src/app/auth/auth.service';
+import { ImageUploadComponent } from 'src/app/shared/components/image-upload/image-upload.component';
 
 @Component({
   selector: 'app-crag-gallery',
   templateUrl: './crag-gallery.component.html',
   styleUrls: ['./crag-gallery.component.scss'],
 })
-export class CragGalleryComponent implements OnInit {
+export class CragGalleryComponent {
   @Input() images: string;
+  @Input() cragId: string;
 
   storageUrl = environment.storageUrl;
 
-  constructor(private dialog: MatDialog) {}
-
-  ngOnInit(): void {}
+  constructor(private dialog: MatDialog, private authService: AuthService) {}
 
   onImageClick(image): void {
     this.dialog.open(ImageFullComponent, {
@@ -26,5 +27,19 @@ export class CragGalleryComponent implements OnInit {
       data: { image },
       autoFocus: false,
     });
+  }
+
+  async onAddImagesClick(): Promise<void> {
+    const allowed = await this.authService.guardedAction({});
+
+    if (allowed) {
+      this.dialog.open(ImageUploadComponent, {
+        data: {
+          type: 'crag',
+          entityId: this.cragId,
+        },
+        autoFocus: false,
+      });
+    }
   }
 }

--- a/src/app/pages/crag/crag.component.html
+++ b/src/app/pages/crag/crag.component.html
@@ -101,6 +101,7 @@
       ></app-crag-comments>
 
       <app-crag-gallery
+        [cragId]="crag.id"
         [images]="crag.images"
         *ngIf="activeTab == 'galerija'"
       ></app-crag-gallery>

--- a/src/app/shared/components/image-upload/image-upload.component.html
+++ b/src/app/shared/components/image-upload/image-upload.component.html
@@ -1,0 +1,76 @@
+<mat-dialog-content>
+  <form
+    class="form"
+    [formGroup]="form"
+    (submit)="submit()"
+    fxLayout="column"
+    fxLayoutGap="16px"
+  >
+    <div fxLayout="row" fxLayoutAlign="space-between center">
+      {{ fileName || "Izberi datoteko" }}
+      <button
+        mat-mini-fab
+        type="button"
+        color="primary"
+        class="upload-btn"
+        (click)="fileInput.click(); $event.preventDefault()"
+      >
+        <mat-icon>image</mat-icon>
+      </button>
+      <input
+        id="file"
+        type="file"
+        #fileInput
+        hidden
+        accept="image/png, image/jpeg"
+        (change)="onFileSelected($event)"
+      />
+    </div>
+    <mat-form-field fxFlex="50">
+      <mat-label>Vrsta slike</mat-label>
+      <mat-select formControlName="type">
+        <mat-option value="photo"> Fotografija </mat-option>
+        <mat-option value="diagram"> Skica </mat-option>
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field fxFlex="50">
+      <mat-label>Naslov ali komentar</mat-label>
+      <input
+        matInput
+        type="text"
+        formControlName="description"
+        autocomplete="off"
+      />
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button
+    *ngIf="!submitting"
+    type="button"
+    mat-button
+    [mat-dialog-close]="null"
+  >
+    Prekliči
+  </button>
+  <button
+    *ngIf="!submitting"
+    type="submit"
+    mat-button
+    color="primary"
+    cdkFocusInitial
+    [disabled]="!fileSelected"
+    (click)="submit()"
+  >
+    Potrdi
+  </button>
+  <div
+    *ngIf="submitting"
+    class="w-100"
+    fxLayout="row"
+    fxLayoutAlign="center center"
+  >
+    <mat-spinner diameter="30"></mat-spinner>
+  </div>
+</mat-dialog-actions>

--- a/src/app/shared/components/image-upload/image-upload.component.scss
+++ b/src/app/shared/components/image-upload/image-upload.component.scss
@@ -1,0 +1,3 @@
+.form {
+  width: 270px;
+}

--- a/src/app/shared/components/image-upload/image-upload.component.ts
+++ b/src/app/shared/components/image-upload/image-upload.component.ts
@@ -1,0 +1,75 @@
+import { HttpClient } from '@angular/common/http';
+import { Component, Input } from '@angular/core';
+import { FormControl, FormGroup } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { environment } from 'src/environments/environment';
+
+@Component({
+  selector: 'app-image-upload',
+  templateUrl: './image-upload.component.html',
+  styleUrls: ['./image-upload.component.scss'],
+})
+export class ImageUploadComponent {
+  // these two properties are not yet used but will probably be used to define to which entity should the image be attached to
+  @Input() type: string;
+  @Input() entityId: string;
+
+  fileName = '';
+  fileSelected = false;
+  submitting = false;
+  form = new FormGroup({
+    image: new FormControl(null),
+    type: new FormControl('photo'),
+    description: new FormControl(null),
+  });
+
+  constructor(private http: HttpClient, private snackBar: MatSnackBar) {}
+
+  onFileSelected(event: Event): void {
+    const file = (event.target as HTMLInputElement).files[0];
+
+    if (!file) return;
+
+    this.fileName = file.name;
+    this.fileSelected = true;
+
+    const reader = new FileReader();
+    reader.readAsDataURL(file);
+    reader.onload = () => {
+      this.form.patchValue({
+        image: reader.result,
+      });
+    };
+  }
+
+  submit(): void {
+    if (!this.form.get('image').value) return;
+    this.submitting = true;
+
+    let formData = new FormData();
+    formData.append('image', this.form.get('image').value);
+    formData.append('type', this.form.get('type').value);
+
+    if (this.form.get('description').value) {
+      formData.append('description', this.form.get('description').value);
+    }
+
+    this.http
+      .post(`${environment.apiUrl}/TODO-image-upload-endpoint`, formData)
+      .subscribe({
+        next: () => {
+          this.submitting = false;
+          this.snackBar.open('Fotografija je bila shranjena.', null, {
+            duration: 3000,
+          });
+        },
+        error: () => {
+          this.submitting = false;
+          this.snackBar.open('Fotografije ni bilo mogoče shraniti.', null, {
+            duration: 3000,
+            panelClass: 'error',
+          });
+        },
+      });
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -32,6 +32,7 @@ import { PluralizeNoun } from './pipes/pluralize-noun.pipe';
 import { DataErrorComponent } from './components/data-error/data-error.component';
 import { AscentTypeComponent } from './components/ascent-type/ascent-type.component';
 import { AscentPublishOptionComponent } from './components/ascent-publish-option/ascent-publish-option.component';
+import { ImageUploadComponent } from './components/image-upload/image-upload.component';
 
 @NgModule({
   declarations: [
@@ -53,6 +54,7 @@ import { AscentPublishOptionComponent } from './components/ascent-publish-option
     PluralizeNoun,
     AscentTypeComponent,
     AscentPublishOptionComponent,
+    ImageUploadComponent,
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
This PR adds a component for uploading images. A button in the crag gallery tab triggers opens the dialog which contains this component.

The component does not actually upload the image because we don't have any endpoint for uploading images.

The design of the dialog is very basic and would probably need a second look.