### PR TITLE
Registration fix

### DIFF
--- a/src/app/pages/account/confirm-account/confirm-account.component.ts
+++ b/src/app/pages/account/confirm-account/confirm-account.component.ts
@@ -1,17 +1,26 @@
-import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Apollo, gql } from 'apollo-angular';
+import { Subscription } from 'rxjs';
+import { AuthService } from 'src/app/auth/auth.service';
 
 @Component({
   selector: 'app-confirm-account',
   templateUrl: './confirm-account.component.html',
   styleUrls: ['./confirm-account.component.scss'],
 })
-export class ConfirmAccountComponent implements OnInit {
+export class ConfirmAccountComponent implements OnInit, OnDestroy {
   loading = true;
   success = false;
 
-  constructor(private activatedRoute: ActivatedRoute, private apollo: Apollo) {}
+  subscription: Subscription;
+
+  constructor(
+    private activatedRoute: ActivatedRoute,
+    private apollo: Apollo,
+    private authService: AuthService,
+    private router: Router
+  ) {}
 
   ngOnInit(): void {
     this.activatedRoute.params.subscribe((params) => {
@@ -37,5 +46,16 @@ export class ConfirmAccountComponent implements OnInit {
           }
         );
     });
+
+    this.subscription = this.authService.currentUser.subscribe((user) => {
+      // user just logged in, navigate to home
+      if (user !== null) {
+        this.router.navigate(['/']);
+      }
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 }

--- a/src/app/pages/account/confirm-account/confirm-account.component.ts
+++ b/src/app/pages/account/confirm-account/confirm-account.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Apollo, gql } from 'apollo-angular';
-import { Subscription } from 'rxjs';
+import { Subscription, switchMap } from 'rxjs';
 import { AuthService } from 'src/app/auth/auth.service';
+import { ConfirmGQL } from 'src/generated/graphql';
 
 @Component({
   selector: 'app-confirm-account',
@@ -17,35 +17,33 @@ export class ConfirmAccountComponent implements OnInit, OnDestroy {
 
   constructor(
     private activatedRoute: ActivatedRoute,
-    private apollo: Apollo,
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private confirmGQL: ConfirmGQL
   ) {}
 
   ngOnInit(): void {
-    this.activatedRoute.params.subscribe((params) => {
-      this.apollo
-        .mutate({
-          mutation: gql`
-          mutation {
-            confirm(input: {
-              id: "${params.id}", 
-              token: "${params.token}"
-            })
-          }
-        `,
+    this.activatedRoute.params
+      .pipe(
+        switchMap((params) => {
+          return this.confirmGQL.mutate({
+            input: {
+              id: params.id,
+              token: params.token,
+            },
+          });
         })
-        .subscribe(
-          () => {
-            this.loading = false;
-            this.success = true;
-          },
-          () => {
-            this.loading = false;
-            this.success = false;
-          }
-        );
-    });
+      )
+      .subscribe({
+        next: () => {
+          this.loading = false;
+          this.success = true;
+        },
+        error: () => {
+          this.loading = false;
+          this.success = false;
+        },
+      });
 
     this.subscription = this.authService.currentUser.subscribe((user) => {
       // user just logged in, navigate to home

--- a/src/app/pages/account/confirm-account/confirm-account.mutation.graphql
+++ b/src/app/pages/account/confirm-account/confirm-account.mutation.graphql
@@ -1,0 +1,3 @@
+mutation Confirm($input: ConfirmInput!) {
+  confirm(input: $input)
+}

--- a/src/app/pages/account/register/register.component.html
+++ b/src/app/pages/account/register/register.component.html
@@ -79,13 +79,13 @@
           </div>
         </div>
 
-        <p class="conditions">
+        <!-- <p class="conditions">
           <mat-checkbox formControlName="conditions"
             >Strinjam se s <a href="#">pogoji uporabe portala</a>
           </mat-checkbox>
-        </p>
+        </p> -->
 
-        <div fxLayout="row" fxLayoutAlign="center center">
+        <div fxLayout="row" fxLayoutAlign="center center" class="mt-16">
           <button
             *ngIf="!loading"
             mat-flat-button

--- a/src/app/pages/account/register/register.component.ts
+++ b/src/app/pages/account/register/register.component.ts
@@ -1,15 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { LayoutService } from 'src/app/services/layout.service';
 import { FormGroup, FormControl, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { RegisterGQL } from 'src/generated/graphql';
+import { AuthService } from 'src/app/auth/auth.service';
+import { Router } from '@angular/router';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-register',
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss'],
 })
-export class RegisterComponent implements OnInit {
+export class RegisterComponent implements OnInit, OnDestroy {
   loading = false;
   success = false;
 
@@ -25,10 +28,14 @@ export class RegisterComponent implements OnInit {
     // conditions: new FormControl(false, [Validators.requiredTrue]),
   });
 
+  subscription: Subscription;
+
   constructor(
     private layoutService: LayoutService,
     private snackbar: MatSnackBar,
-    private registerGQL: RegisterGQL
+    private registerGQL: RegisterGQL,
+    private authService: AuthService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -37,6 +44,13 @@ export class RegisterComponent implements OnInit {
         name: 'Registracija',
       },
     ]);
+
+    this.subscription = this.authService.currentUser.subscribe((user) => {
+      // user just logged in, navigate to home
+      if (user !== null) {
+        this.router.navigate(['/']);
+      }
+    });
   }
 
   register() {
@@ -76,5 +90,9 @@ export class RegisterComponent implements OnInit {
           });
         },
       });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 }

--- a/src/app/pages/account/register/register.component.ts
+++ b/src/app/pages/account/register/register.component.ts
@@ -22,7 +22,7 @@ export class RegisterComponent implements OnInit {
     firstname: new FormControl('', [Validators.required]),
     lastname: new FormControl('', [Validators.required]),
     gender: new FormControl(''),
-    conditions: new FormControl(false, [Validators.requiredTrue]),
+    // conditions: new FormControl(false, [Validators.requiredTrue]),
   });
 
   constructor(

--- a/src/app/pages/account/select-password/select-password.component.ts
+++ b/src/app/pages/account/select-password/select-password.component.ts
@@ -1,8 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Apollo, gql } from 'apollo-angular';
+import { Subscription } from 'rxjs';
+import { AuthService } from 'src/app/auth/auth.service';
 import { LayoutService } from 'src/app/services/layout.service';
 
 @Component({
@@ -10,7 +12,7 @@ import { LayoutService } from 'src/app/services/layout.service';
   templateUrl: './select-password.component.html',
   styleUrls: ['./select-password.component.scss'],
 })
-export class SelectPasswordComponent implements OnInit {
+export class SelectPasswordComponent implements OnInit, OnDestroy {
   loading = false;
   success = false;
 
@@ -23,11 +25,15 @@ export class SelectPasswordComponent implements OnInit {
     token: new FormControl(''),
   });
 
+  subscription: Subscription;
+
   constructor(
     private layoutService: LayoutService,
     private apollo: Apollo,
     private snackbar: MatSnackBar,
-    private activatedRoute: ActivatedRoute
+    private activatedRoute: ActivatedRoute,
+    private authService: AuthService,
+    private router: Router
   ) {}
 
   ngOnInit(): void {
@@ -39,6 +45,13 @@ export class SelectPasswordComponent implements OnInit {
 
     this.activatedRoute.params.subscribe((params) => {
       this.form.patchValue(params);
+    });
+
+    this.subscription = this.authService.currentUser.subscribe((user) => {
+      // user just logged in, navigate to home
+      if (user !== null) {
+        this.router.navigate(['/']);
+      }
     });
   }
 
@@ -74,5 +87,9 @@ export class SelectPasswordComponent implements OnInit {
           });
         }
       );
+  }
+
+  ngOnDestroy(): void {
+    this.subscription.unsubscribe();
   }
 }

--- a/src/app/pages/account/select-password/select-password.component.ts
+++ b/src/app/pages/account/select-password/select-password.component.ts
@@ -2,10 +2,10 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute, Router } from '@angular/router';
-import { Apollo, gql } from 'apollo-angular';
 import { Subscription } from 'rxjs';
 import { AuthService } from 'src/app/auth/auth.service';
 import { LayoutService } from 'src/app/services/layout.service';
+import { SetPasswordGQL } from 'src/generated/graphql';
 
 @Component({
   selector: 'app-select-password',
@@ -29,11 +29,11 @@ export class SelectPasswordComponent implements OnInit, OnDestroy {
 
   constructor(
     private layoutService: LayoutService,
-    private apollo: Apollo,
     private snackbar: MatSnackBar,
     private activatedRoute: ActivatedRoute,
     private authService: AuthService,
-    private router: Router
+    private router: Router,
+    private setPasswordGQL: SetPasswordGQL
   ) {}
 
   ngOnInit(): void {
@@ -60,23 +60,15 @@ export class SelectPasswordComponent implements OnInit, OnDestroy {
 
     const value = this.form.value;
 
-    this.apollo
+    this.setPasswordGQL
       .mutate({
-        mutation: gql`
-        mutation {
-          setPassword(input: {
-            id: "${value.id}", 
-            token: "${value.token}", 
-            password: "${value.password}"
-          })
-        }
-      `,
+        input: { id: value.id, token: value.token, password: value.password },
       })
-      .subscribe(
-        () => {
+      .subscribe({
+        next: () => {
           this.success = true;
         },
-        (error) => {
+        error: () => {
           this.loading = false;
 
           let message =
@@ -85,8 +77,8 @@ export class SelectPasswordComponent implements OnInit, OnDestroy {
             panelClass: 'error',
             duration: 3000,
           });
-        }
-      );
+        },
+      });
   }
 
   ngOnDestroy(): void {

--- a/src/app/pages/account/select-password/select-password.mutation.graphql
+++ b/src/app/pages/account/select-password/select-password.mutation.graphql
@@ -1,0 +1,3 @@
+mutation SetPassword($input: PasswordInput!) {
+  setPassword(input: $input)
+}


### PR DESCRIPTION
Redirects to home after user logs in on registration, activation or password reset page. 
(These views are not supposed to be seen by a logged in user.)

Also some minor cleanup:
- moves some gql mutations to .graphql files, 
- fixes a nested subscription
- replaces deprecated observers signatures

Test by going through the process of:
- registering as a new user,
- password reset
and see that everything still works. 
Try logging in on each of the views presented.

closes #264 

(note: could not replicate infinite spinner, so that might have been a false bug report...)