### PR TITLE
Disable searching for users.

### DIFF
--- a/src/app/pages/search/search-results/search-results.component.html
+++ b/src/app/pages/search/search-results/search-results.component.html
@@ -149,7 +149,7 @@
           </div>
         </mat-tab>
 
-        <mat-tab label="Uporabniki ({{ searchResults.users.length }})">
+        <!-- <mat-tab label="Uporabniki ({{ searchResults.users.length }})">
           <div *ngIf="!searchResults.users.length" class="results-tab">
             Za iskalni niz "{{ searchString }}" med uporabniki ni rezultatov :(
           </div>
@@ -177,7 +177,7 @@
               </div>
             </div>
           </div>
-        </mat-tab>
+        </mat-tab> -->
 
         <mat-tab label="Komentarji ({{ searchResults.comments.length }})">
           <div *ngIf="!searchResults.comments.length" class="results-tab">

--- a/src/app/pages/search/search-results/search-results.component.ts
+++ b/src/app/pages/search/search-results/search-results.component.ts
@@ -55,7 +55,7 @@ export class SearchResultsComponent implements OnInit {
             this.searchResults.crags,
             this.searchResults.routes,
             this.searchResults.sectors,
-            this.searchResults.users,
+            // this.searchResults.users,  // Searching for users is temporarily disabled
             this.searchResults.comments,
           ].findIndex((val) => val.length > 0);
 

--- a/src/app/pages/search/search-results/search.query.graphql
+++ b/src/app/pages/search/search-results/search.query.graphql
@@ -86,10 +86,12 @@ query Search($query: String) {
       }
       created
     }
-    users {
-      __typename
-      id
-      fullName
-    }
+
+    # Searching for users is temporarily disabled.
+    # users {
+    #   __typename
+    #   id
+    #   fullName
+    # }
   }
 }

--- a/src/app/pages/search/search.component.html
+++ b/src/app/pages/search/search.component.html
@@ -11,7 +11,7 @@
         type="text"
         matInput
         type="text"
-        placeholder="Poišči plezališče, smer, sektor, uporabnika ali komentar"
+        placeholder="Poišči plezališče, smer, sektor ali komentar"
         formControlName="searchControl"
         [matAutocomplete]="auto"
       />
@@ -49,7 +49,7 @@
             </mat-option>
           </mat-optgroup>
 
-          <mat-optgroup *ngIf="searchResults?.users.length" label="Uporabniki">
+          <mat-optgroup *ngIf="searchResults?.users?.length" label="Uporabniki">
             <mat-option *ngFor="let user of searchResults.users" [value]="user">
               {{ user.fullName }}
             </mat-option>

--- a/src/app/pages/search/searchAutoComplete.query.graphql
+++ b/src/app/pages/search/searchAutoComplete.query.graphql
@@ -28,10 +28,11 @@ query SearchAutoComplete($searchString: String) {
       }
     }
 
-    users {
-      __typename
-      id
-      fullName
-    }
+    # Searching for users is temporarily disabled.
+    # users {
+    #   __typename
+    #   id
+    #   fullName
+    # }
   }
 }


### PR DESCRIPTION
Search does not search for users anymore.
(user links are not working yet, because user profile page does not exist yet).

Test by searching for a user. Observe that the user is not displayed in search autocomplete nor on search results page.

closes #271 