### PR TITLE
Add component that can generate a picture tag

### DIFF
--- a/src/app/common/image-full/image-full.component.html
+++ b/src/app/common/image-full/image-full.component.html
@@ -12,27 +12,15 @@
     fxLayoutAlign="center center"
   >
     <div fxLayout="column" class="image-w-caption-wrap">
-      <img
-        [srcset]="
-          storageUrl +
-          '/images/300/' +
-          data.image.path +
-          ' 300w, ' +
-          storageUrl +
-          '/images/600/' +
-          data.image.path +
-          ' 600w, ' +
-          storageUrl +
-          '/images/1040/' +
-          data.image.path +
-          ' 1040w'
-        "
-        sizes="100vw"
-        [src]="storageUrl + '/images/1040/' + data.image.path"
-        [alt]="data.image.title"
+      <app-responsive-image
         fxFlex="90%"
         fxLayoutAlign="center center"
-      />
+        [imageWidths]="[300, 600, 1040]"
+        [fallbackWidth]="1040"
+        [imagePath]="data.image.path"
+        [renderSizes]="'100vw'"
+        [imageAlt]="data.image.title"
+      ></app-responsive-image>
 
       <div class="caption">
         <div>

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.html
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.html
@@ -7,25 +7,21 @@
     fxLayoutAlign="center center"
   >
     <div class="card">
-      <img
-        [srcset]="
-          storageUrl +
-          '/images/300/' +
-          image.path +
-          ' 300w, ' +
-          storageUrl +
-          '/images/600/' +
-          image.path +
-          ' 600w'
+      <app-responsive-image
+        [imageWidths]="[300, 600]"
+        [imagePath]="image.path"
+        renderSizes="
+          (max-width: 599px) calc(50vw - 56.5px),
+          (max-width: 904px) calc(50vw - 72.5px),
+          (max-width: 1239px) 231.5px,
+          (max-width: 1439px) calc(33.33vw - 182px),
+          298px
         "
-        sizes="(max-width: 599px) calc(50vw - 56.5px),
-        (max-width: 904px) calc(50vw - 72.5px),
-        (max-width: 1239px) 231.5px,
-        (max-width: 1439px) calc(33.33vw - 182px),
-        298px"
-        [src]="storageUrl + '/images/600/' + image.path"
+        [fallbackWidth]="600"
+        [imageAlt]="image.title"
         (click)="onImageClick(image)"
-      />
+      ></app-responsive-image>
+
       <div class="title">{{ image.title }}</div>
     </div>
   </div>

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.scss
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.scss
@@ -2,11 +2,6 @@
   padding: 12px;
   .card {
     padding: 8px;
-    img {
-      display: block;
-      max-height: 400px;
-      max-width: 100%;
-    }
     .title {
       padding-top: 4px;
     }

--- a/src/app/pages/crag/crag-image/crag-image.component.html
+++ b/src/app/pages/crag/crag-image/crag-image.component.html
@@ -1,22 +1,14 @@
 <div *ngIf="crag.images.length > 0" class="card no-border">
-  <img
-    [srcset]=""
-    [srcset]="
-      storageUrl +
-      '/images/300/' +
-      crag.images[0].path +
-      ' 300w, ' +
-      storageUrl +
-      '/images/600/' +
-      crag.images[0].path +
-      ' 600w'
-    "
-    sizes="
-        (max-width: 1239px) 276.97px,
-        (max-width: 1439px) calc(33.33vw - 145.32px),
-        334.63px"
-    [src]="storageUrl + '/images/600/' + crag.images[0].path"
-    [alt]="crag.images[0].title"
-  />
+  <app-responsive-image
+    [imageWidths]="[300, 600]"
+    [fallbackWidth]="600"
+    [imagePath]="crag.images[0].path"
+    renderSizes="
+      (max-width: 1239px) 276.97px,
+      (max-width: 1439px) calc(33.33vw - 145.32px),
+      334.63px"
+    [imageAlt]="crag.images[0].title"
+  ></app-responsive-image>
+
   <!-- TODO: Should have crag-cover-image field on crag instead of simply displaying first image? -->
 </div>

--- a/src/app/pages/crag/crag-image/crag-image.component.scss
+++ b/src/app/pages/crag/crag-image/crag-image.component.scss
@@ -1,7 +1,5 @@
-img {
+app-responsive-image {
   cursor: pointer;
-  width: 100%;
-  display: block;
 }
 .card {
   padding: 12px 6px;

--- a/src/app/pages/home/latest-images/latest-images.component.html
+++ b/src/app/pages/home/latest-images/latest-images.component.html
@@ -2,25 +2,18 @@
 <mat-grid-list [cols]="ncols" rowHeight="1:1" gutterSize="4px" *ngIf="!loading">
   <mat-grid-tile *ngFor="let image of latestImages">
     <div class="wrap" (click)="onImageClick(image)">
-      <!-- <img [src]="storageUrl + '/images/' + image.path" /> -->
-      <img
-        [srcset]="
-          storageUrl +
-          '/images/300/' +
-          image.path +
-          ' 300w, ' +
-          storageUrl +
-          '/images/600/' +
-          image.path +
-          ' 600w'
-        "
-        sizes="(max-width: 599px) calc(100vw - 32px),
-        (max-width: 904px) calc(50vw - 34px),
-        (max-width: 1239px) 277.33px,
-        (max-width: 1439px) calc(25vw - 103px),
+      <app-responsive-image
+        [imageWidths]="[300, 600]"
+        [fallbackWidth]="600"
+        [imagePath]="image.path"
+        renderSizes="
+          (max-width: 599px) calc(100vw - 32px),
+          (max-width: 904px) calc(50vw - 34px),
+          (max-width: 1239px) 277.33px,
+          (max-width: 1439px) calc(25vw - 103px),
           257px"
-        [src]="storageUrl + '/images/600/' + image.path"
-      />
+        [imageAlt]="image.title"
+      ></app-responsive-image>
 
       <div class="info" fxLayout="row" fxLayoutAlign="center center">
         <div>{{ image.title }}</div>

--- a/src/app/pages/home/latest-images/latest-images.component.scss
+++ b/src/app/pages/home/latest-images/latest-images.component.scss
@@ -17,12 +17,6 @@ h2 {
   height: 100%;
   cursor: pointer;
 
-  img {
-    object-fit: cover;
-    width: 100%;
-    height: 100%;
-  }
-
   .info {
     position: absolute;
     top: 0;
@@ -39,9 +33,5 @@ h2 {
   &:hover .info {
     background-color: rgba(255, 255, 255, 0.8);
     opacity: 1;
-  }
-
-  &:hover img {
-    filter: grayscale(100%);
   }
 }

--- a/src/app/shared/components/responsive-image/responsive-image.component.html
+++ b/src/app/shared/components/responsive-image/responsive-image.component.html
@@ -1,0 +1,9 @@
+<picture>
+  <source type="image/avif" [srcset]="avifSrcset" [sizes]="renderSizes" />
+  <source type="image/webp" [srcset]="webpSrcset" [sizes]="renderSizes" />
+  <source type="image/jpg" [srcset]="jpgSrcset" [sizes]="renderSizes" />
+  <img
+    [src]="storageUrl + '/images/' + fallbackWidth + '/' + imagePath + '.jpg'"
+    [alt]="imageAlt"
+  />
+</picture>

--- a/src/app/shared/components/responsive-image/responsive-image.component.scss
+++ b/src/app/shared/components/responsive-image/responsive-image.component.scss
@@ -1,0 +1,6 @@
+img {
+  object-fit: cover;
+  height: 100%;
+  width: 100%;
+  display: block;
+}

--- a/src/app/shared/components/responsive-image/responsive-image.component.ts
+++ b/src/app/shared/components/responsive-image/responsive-image.component.ts
@@ -1,0 +1,39 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { environment } from 'src/environments/environment';
+
+@Component({
+  selector: 'app-responsive-image',
+  templateUrl: './responsive-image.component.html',
+  styleUrls: ['./responsive-image.component.scss'],
+})
+export class ResponsiveImageComponent implements OnInit {
+  @Input() imageWidths: number[];
+  @Input() fallbackWidth: number;
+  @Input() imagePath: string;
+  @Input() renderSizes: string;
+  @Input() imageAlt: string;
+
+  storageUrl = environment.storageUrl;
+
+  avifSrcset: string;
+  webpSrcset: string;
+  jpgSrcset: string;
+
+  constructor() {}
+
+  ngOnInit(): void {
+    this.avifSrcset = this.generateSrcset(this.imageWidths, 'avif');
+    this.webpSrcset = this.generateSrcset(this.imageWidths, 'webp');
+    this.jpgSrcset = this.generateSrcset(this.imageWidths, 'jpg');
+  }
+
+  private generateSrcset(imageWidths: number[], format: string) {
+    return imageWidths
+      .reduce(
+        (prev: string, size: number) =>
+          `${prev}${this.storageUrl}/images/${size}/${this.imagePath}.${format} ${size}w, `,
+        ''
+      )
+      .slice(0, -2);
+  }
+}

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -32,6 +32,7 @@ import { PluralizeNoun } from './pipes/pluralize-noun.pipe';
 import { DataErrorComponent } from './components/data-error/data-error.component';
 import { AscentTypeComponent } from './components/ascent-type/ascent-type.component';
 import { AscentPublishOptionComponent } from './components/ascent-publish-option/ascent-publish-option.component';
+import { ResponsiveImageComponent } from './components/responsive-image/responsive-image.component';
 
 @NgModule({
   declarations: [
@@ -53,6 +54,7 @@ import { AscentPublishOptionComponent } from './components/ascent-publish-option
     PluralizeNoun,
     AscentTypeComponent,
     AscentPublishOptionComponent,
+    ResponsiveImageComponent,
   ],
   imports: [
     CommonModule,
@@ -92,6 +94,7 @@ import { AscentPublishOptionComponent } from './components/ascent-publish-option
     MatInputModule,
     GradeComponent,
     PluralizeNoun,
+    ResponsiveImageComponent,
   ],
 })
 export class SharedModule {}


### PR DESCRIPTION
Images are now displayed in relevant sizes (chosen by browser via srcset) and using next gen formats with fallbacks. 
avif->webp->jpeg

To test this might wait until all images in these formats are processed and uploaded to server.
Also can wait for BE migration that will remove image filename extensions from filepaths in db.

If you want to test now, try with images (already uploaded):
-misja-pec
-geyikbayiri-wild-horses
and localy delete their .jpg extension in path in db.

(note: fulsize image popup layout is broken. will be fixed with another issue)

closes #276 
