### PR TITLE
Limit height of picture in gallery

### DIFF
--- a/src/app/common/image-full/image-full.component.html
+++ b/src/app/common/image-full/image-full.component.html
@@ -1,4 +1,4 @@
-<div fxFlexFill fxLayout="column" (click)="onClick()">
+<div class="container" (click)="onClick()">
   <div class="button-row">
     <button mat-icon-button>
       <mat-icon>close</mat-icon>

--- a/src/app/common/image-full/image-full.component.scss
+++ b/src/app/common/image-full/image-full.component.scss
@@ -1,3 +1,9 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 .button-row {
   height: 40px;
   width: 100%;

--- a/src/app/shared/components/responsive-image/responsive-image.component.scss
+++ b/src/app/shared/components/responsive-image/responsive-image.component.scss
@@ -4,3 +4,7 @@ img {
   width: 100%;
   display: block;
 }
+
+picture {
+  height: 100%;
+}


### PR DESCRIPTION
Prevents bug where image is larger than 90vh/% which causes the description text to overlap the image.