### PR TITLE
Remove links to user profiles on home.

### DIFF
--- a/src/app/pages/home/latest-ticks/latest-ticks.component.html
+++ b/src/app/pages/home/latest-ticks/latest-ticks.component.html
@@ -12,9 +12,7 @@
           <tbody>
             <tr *ngFor="let tick of tickGroup.ticks">
               <td>
-                <a [routerLink]="['/uporabniki', tick.user.fullName]">
-                  {{ tick.user.fullName }}
-                </a>
+                {{ tick.user.fullName }}
                 je
                 {{ tick.ascentType | ascentType }}
                 {{ "preplezal" | genderizeVerb: tick.user.gender }}


### PR DESCRIPTION
User profile page does not exist yet, so links to it fail. 
Removing links.
To test go to homepage and see that users are displayed as text only.