### PR TITLE
Do not refetch queries on login.

### DIFF
--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -34,7 +34,7 @@ export class AuthService {
   }
 
   async login(loginResponse: LoginResponse): Promise<any> {
-    await this.apollo.client.resetStore();
+    await this.apollo.client.clearStore();
     this.localStorageService.setItem(
       'auth',
       loginResponse,


### PR DESCRIPTION
This PR fixes a bug, which can be reproduced as follows:
1. Log in
2. Go to log, and delete any activity entry
3. Logout
4. Log in again
5. Observe that you get stuck with infinite spinner and that you get an  uncaught auth error in the console.

Reason:
When logging in we were calling resetStore which deletes apollo cache and also refetches queries. Refetching queries caused auth error which was not caught.

Solution:
Use clearStore which only deletes cache.

Try above procedure again and see that it works now.
