### PR TITLE
Graphql retry link

### DIFF
--- a/src/app/graphql/graphql.module.ts
+++ b/src/app/graphql/graphql.module.ts
@@ -6,6 +6,7 @@ import {
   InMemoryCache,
 } from '@apollo/client/core';
 import { onError } from '@apollo/client/link/error';
+import { RetryLink } from '@apollo/client/link/retry';
 import { HttpLink } from 'apollo-angular/http';
 import { environment } from 'src/environments/environment';
 import * as Sentry from '@sentry/angular';
@@ -26,9 +27,15 @@ const errorLink = onError(({ graphQLErrors, networkError }) => {
   }
 });
 
+const retryLink = new RetryLink({
+  delay: {
+    initial: 500,
+  },
+});
+
 export function createApollo(httpLink: HttpLink): ApolloClientOptions<any> {
   return {
-    link: ApolloLink.from([errorLink, httpLink.create({ uri })]),
+    link: ApolloLink.from([errorLink, retryLink, httpLink.create({ uri })]),
     cache: new InMemoryCache({
       typePolicies: {
         Crag: {


### PR DESCRIPTION
Adding retry mechanism to apollo client. On server error (for example when api is getting deployed) it will try 5 times before resulting in error, starting with 500ms delay.

To test this, open a crag, turn off api, refresh and turn on api. You will see a few failed requests in network, depending on how quick you switched the api back on :)

This should be deployed before any api PR.