### PR TITLE
#101 fix mobile layout of club log for the table and filters

### DIFF
--- a/src/app/pages/club/club-activity-routes/club-activity-routes.component.html
+++ b/src/app/pages/club/club-activity-routes/club-activity-routes.component.html
@@ -1,8 +1,14 @@
 <div *ngIf="!error">
   <div class="container mt-16">
     <div>
-      <div fxLayout="row" [formGroup]="filters" fxLayoutGap="8px">
-        <mat-form-field appearance="fill">
+      <div
+        fxLayout="row"
+        fxLayout.lt-sm="column"
+        [formGroup]="filters"
+        fxLayoutGap="16px"
+        class="mb-16"
+      >
+        <mat-form-field appearance="fill" class="no-hint">
           <mat-label>Časovno obdobje</mat-label>
           <mat-date-range-input [rangePicker]="picker">
             <input
@@ -45,7 +51,7 @@
           >
         </mat-form-field>
 
-        <mat-form-field>
+        <mat-form-field class="no-hint">
           <mat-label>Vrsta vzpona</mat-label>
           <mat-select formControlName="ascentType" multiple>
             <mat-option *ngFor="let type of ascentTypes" [value]="type.value"
@@ -56,6 +62,7 @@
 
         <mat-form-field
           *ngIf="filterMemberFullName && filters.controls.userId.value"
+          class="no-hint"
         >
           <mat-label>Član</mat-label>
           <input matInput [value]="filterMemberFullName" disabled />
@@ -71,6 +78,7 @@
 
         <mat-form-field
           *ngIf="filterRouteName && filters.controls.routeId.value"
+          class="no-hint"
         >
           <mat-label>Smer</mat-label>
           <input matInput [value]="filterRouteName" disabled />
@@ -84,7 +92,10 @@
         </mat-form-field>
         <input type="hidden" formControlName="routeId" />
 
-        <mat-form-field *ngIf="filterCragName && filters.controls.cragId.value">
+        <mat-form-field
+          *ngIf="filterCragName && filters.controls.cragId.value"
+          class="no-hint"
+        >
           <mat-label>Plezališče</mat-label>
           <input matInput [value]="filterCragName" disabled />
           <button
@@ -98,7 +109,7 @@
         <input type="hidden" formControlName="cragId" />
       </div>
 
-      <div class="card">
+      <div class="card scrollable-table">
         <div class="card-loader" *ngIf="loading">
           <app-loader></app-loader>
         </div>

--- a/src/app/pages/club/club-activity-routes/club-activity-routes.component.scss
+++ b/src/app/pages/club/club-activity-routes/club-activity-routes.component.scss
@@ -1,0 +1,4 @@
+.scrollable-table {
+  max-width: 100%;
+  overflow-x: auto;
+}

--- a/src/app/pages/club/club-activity-routes/club-activity-routes.component.scss
+++ b/src/app/pages/club/club-activity-routes/club-activity-routes.component.scss
@@ -1,4 +1,7 @@
 .scrollable-table {
   max-width: 100%;
   overflow-x: auto;
+  .card-table {
+    min-width: 980px;
+  }
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -59,6 +59,10 @@ body {
   margin-top: 16px;
 }
 
+.mb-16 {
+  margin-bottom: 16px;
+}
+
 .mb-32 {
   margin-bottom: 32px;
 }


### PR DESCRIPTION
## Description
issue: https://github.com/plezanje-net/api/issues/101

Fixes the layout on small screen sizes for the club activity routes log.

Example of broken layout:
![image](https://user-images.githubusercontent.com/6022408/161835689-52dc87f5-a612-42d5-b078-83fcea95ebe3.png)


Example of fixed layout:

https://user-images.githubusercontent.com/6022408/161835739-20bfad13-7704-4e1b-8ee9-ad2cdc080298.mp4


I also reduced the gap between the input fields for sorting. Previously it was 8px, now it's 16px (the same as in activity log or activity form).