### PR TITLE
Responsive image update

### DIFF
--- a/src/app/common/image-full/image-full.component.html
+++ b/src/app/common/image-full/image-full.component.html
@@ -1,28 +1,28 @@
-<div class="container" (click)="onClick()">
-  <div class="button-row">
+<div class="full-container">
+  <div class="close-button-row" (click)="onCloseClick()">
     <button mat-icon-button>
       <mat-icon>close</mat-icon>
     </button>
   </div>
 
-  <div
-    class="image-row"
-    fxFlex="1 1 0%"
-    fxLayout="column"
-    fxLayoutAlign="center center"
-  >
-    <div fxLayout="column" class="image-w-caption-wrap">
+  <div class="navi-image-caption-row">
+    <div class="navi-col">
+      <button mat-icon-button (click)="onPreviousImageClick()">
+        <mat-icon>navigate_before</mat-icon>
+      </button>
+    </div>
+
+    <div class="image-w-caption-wrap" (click)="onCloseClick()">
       <app-responsive-image
-        fxFlex="90%"
-        fxLayoutAlign="center center"
         [imageWidths]="[300, 600, 1040]"
         [fallbackWidth]="1040"
         [imagePath]="data.image.path"
-        [renderSizes]="'100vw'"
+        [renderSizes]="renderSizes"
+        [maxIntrinsicWidth]="data.image.maxIntrinsicWidth"
         [imageAlt]="data.image.title"
       ></app-responsive-image>
 
-      <div class="caption">
+      <div class="caption-wrap">
         <div>
           <span *ngIf="data.image.title">
             <span>{{ data.image.title }}</span>
@@ -53,18 +53,18 @@
             >{{ data.image.crag.name }}</a
           >
         </div>
-        <div
-          *ngIf="data.image.user"
-          class="author"
-          fxLayout="row"
-          fxLayoutAlign="center center"
-        >
+        <div *ngIf="data.image.user" class="author">
           <mat-icon>photo_camera</mat-icon>
           <span>
             {{ data.image.user.fullName }}
           </span>
         </div>
       </div>
+    </div>
+    <div class="navi-col">
+      <button mat-icon-button (click)="onNextImageClick()">
+        <mat-icon>navigate_next</mat-icon>
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/common/image-full/image-full.component.html
+++ b/src/app/common/image-full/image-full.component.html
@@ -7,7 +7,11 @@
 
   <div class="navi-image-caption-row">
     <div class="navi-col">
-      <button mat-icon-button (click)="onPreviousImageClick()">
+      <button
+        mat-icon-button
+        (click)="onPreviousImageClick()"
+        [disabled]="currentImageIndex < 1"
+      >
         <mat-icon>navigate_before</mat-icon>
       </button>
     </div>
@@ -16,53 +20,57 @@
       <app-responsive-image
         [imageWidths]="[300, 600, 1040]"
         [fallbackWidth]="1040"
-        [imagePath]="data.image.path"
+        [imagePath]="image.path"
         [renderSizes]="renderSizes"
-        [maxIntrinsicWidth]="data.image.maxIntrinsicWidth"
-        [imageAlt]="data.image.title"
+        [maxIntrinsicWidth]="image.maxIntrinsicWidth"
+        [imageAlt]="image.title"
       ></app-responsive-image>
 
       <div class="caption-wrap">
         <div>
-          <span *ngIf="data.image.title">
-            <span>{{ data.image.title }}</span>
-            <span *ngIf="data.image.route || data.image.crag">, </span>
+          <span *ngIf="image.title">
+            <span>{{ image.title }}</span>
+            <span *ngIf="image.route || image.crag">, </span>
           </span>
 
-          <span *ngIf="data.image.route">
+          <span *ngIf="image.route">
             <span>smer </span>
             <a
-              *ngIf="data.image.route"
+              *ngIf="image.route"
               [routerLink]="[
                 '/plezalisce',
-                data.image.route.crag.slug,
+                image.route.crag.slug,
                 'smer',
-                data.image.route.slug
+                image.route.slug
               ]"
-              >{{ data.image.route.name }}</a
+              >{{ image.route.name }}</a
             >, plezališče
-            <a [routerLink]="['/plezalisce', data.image.route.crag.slug]">{{
-              data.image.route.crag.name
+            <a [routerLink]="['/plezalisce', image.route.crag.slug]">{{
+              image.route.crag.name
             }}</a>
           </span>
 
-          <span *ngIf="data.image.crag && !data.image.route">plezališče </span>
+          <span *ngIf="image.crag && !image.route">plezališče </span>
           <a
-            *ngIf="data.image.crag"
-            [routerLink]="['/plezalisce', data.image.crag.slug]"
-            >{{ data.image.crag.name }}</a
+            *ngIf="image.crag"
+            [routerLink]="['/plezalisce', image.crag.slug]"
+            >{{ image.crag.name }}</a
           >
         </div>
-        <div *ngIf="data.image.user" class="author">
+        <div *ngIf="image.user" class="author">
           <mat-icon>photo_camera</mat-icon>
           <span>
-            {{ data.image.user.fullName }}
+            {{ image.user.fullName }}
           </span>
         </div>
       </div>
     </div>
     <div class="navi-col">
-      <button mat-icon-button (click)="onNextImageClick()">
+      <button
+        mat-icon-button
+        (click)="onNextImageClick()"
+        [disabled]="currentImageIndex > images.length - 2"
+      >
         <mat-icon>navigate_next</mat-icon>
       </button>
     </div>

--- a/src/app/common/image-full/image-full.component.scss
+++ b/src/app/common/image-full/image-full.component.scss
@@ -1,42 +1,84 @@
-.container {
+.full-container {
+  min-height: 100%;
   display: flex;
   flex-direction: column;
-  height: 100%;
+  box-sizing: border-box;
+
+  // background-color: antiquewhite;
 }
 
-.button-row {
+.close-button-row {
   height: 40px;
-  width: 100%;
   text-align: right;
+
+  // background-color: cornflowerblue;
 }
 
-.image-row {
-  overflow: auto;
+.navi-image-caption-row {
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0%;
+
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  // background-color: violet;
 }
 
-.image-w-caption-wrap {
-  max-height: 100%;
-  place-content: center;
-}
-
-img {
-  max-height: 100%;
-  max-width: 100%;
-  object-fit: scale-down;
-}
-
-.caption {
-  margin-top: 4px;
+.navi-col {
+  width: 40px;
   text-align: center;
 }
 
+.image-w-caption-wrap {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  // background-color: aquamarine;
+}
+
+// ::ng-deep img {
+//   margin: auto;
+//   display: block;
+
+//   /* flex-grow: 0; not needed anymore --> keep until tested in all browsers.
+//   flex-shrink: 0;
+//   flex-basis: auto;
+//   background-color: pink; */
+
+//   /* max-width: 100%; not needed anymore?? */
+//   /* deduct top and bottom padding of overlay and what is reserved for the caption> 60 + 30 + 30 */
+//   /* max-height: calc(100vh - 160px); not needed anymore??*/
+
+//   /* object-fit: scale-down;  not needed anymore ??? --> keep in comment, test with some strange browsers, then remove */
+// }
+
+.caption-wrap {
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 64px;
+  text-align: center;
+
+  padding-top: 4px;
+
+  // background-color: lightsalmon;
+}
+
 .author {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+
   mat-icon {
     font-size: 12px;
     line-height: 12px;
     width: 12px;
     height: 12px;
   }
+
   span {
     margin-left: 4px;
   }

--- a/src/app/common/image-full/image-full.component.ts
+++ b/src/app/common/image-full/image-full.component.ts
@@ -11,13 +11,35 @@ import { Image } from 'src/generated/graphql';
 export class ImageFullComponent {
   storageUrl = environment.storageUrl;
 
+  renderSizes: string;
+
   constructor(
     public dialogRef: MatDialogRef<ImageFullComponent>,
     @Inject(MAT_DIALOG_DATA)
     public data: { image: Image }
-  ) {}
+  ) {
+    // Generate renderSizes parameter here, to make it more readable
+    // Image is alway rendered 'by width' by the browser.
+    // Limitations of the image width can be either: height of the viewport, width of the viewport, intrinsic width of the image (user uploaded a too small image...)
+    this.renderSizes = `min(calc((100vh - 152px) * ${data.image.aspectRatio}), calc(100vw - 128px), ${data.image.maxIntrinsicWidth}px)`;
+    // not very nice, but is explained like this>
+    // For height:
+    //  matDialog padding: 24px (top), 24px (bottom), Caption has fixed height: 64px, Close button has fixed height: 40px. ∑ = 152px
+    // For width:
+    // matDialof padding: 24px (left), 24px (right), Prev button 40px, Next button 40px. ∑ = 128px
+  }
 
-  onClick() {
+  onCloseClick() {
     this.dialogRef.close();
+  }
+
+  onNextImageClick() {
+    // TODO:
+    console.log('display next');
+  }
+
+  onPreviousImageClick() {
+    // TODO:
+    console.log('display previous');
   }
 }

--- a/src/app/common/image-full/image-full.component.ts
+++ b/src/app/common/image-full/image-full.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject } from '@angular/core';
+import { Component, HostListener, Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { environment } from 'src/environments/environment';
 import { Image } from 'src/generated/graphql';
@@ -11,35 +11,52 @@ import { Image } from 'src/generated/graphql';
 export class ImageFullComponent {
   storageUrl = environment.storageUrl;
 
-  renderSizes: string;
+  images: Image[];
+
+  currentImageIndex: number;
+  image: Image;
 
   constructor(
     public dialogRef: MatDialogRef<ImageFullComponent>,
     @Inject(MAT_DIALOG_DATA)
-    public data: { image: Image }
+    public data: { images: Image[]; currentImageIndex: number }
   ) {
-    // Generate renderSizes parameter here, to make it more readable
-    // Image is alway rendered 'by width' by the browser.
-    // Limitations of the image width can be either: height of the viewport, width of the viewport, intrinsic width of the image (user uploaded a too small image...)
-    this.renderSizes = `min(calc((100vh - 152px) * ${data.image.aspectRatio}), calc(100vw - 128px), ${data.image.maxIntrinsicWidth}px)`;
-    // not very nice, but is explained like this>
-    // For height:
-    //  matDialog padding: 24px (top), 24px (bottom), Caption has fixed height: 64px, Close button has fixed height: 40px. ∑ = 152px
-    // For width:
-    // matDialof padding: 24px (left), 24px (right), Prev button 40px, Next button 40px. ∑ = 128px
+    this.images = this.data.images;
+    this.currentImageIndex = this.data.currentImageIndex;
+    this.image = this.images[this.currentImageIndex];
+  }
+
+  /**
+   * Generate renderSizes parameter here, to make it more readable
+   * Image is alway rendered 'by width' by the browser.
+   * Limitations of the image width can be either: height of the viewport, width of the viewport, intrinsic width of the image (user uploaded a too small image...)
+   * Below px values are explained as follows:
+   *  For height:
+   *    matDialog padding: 24px (top), 24px (bottom), Caption has fixed height: 64px, Close button has fixed height: 40px. ∑ = 152px
+   *  For width:
+   *    matDialog padding: 24px (left), 24px (right), Prev button 40px, Next button 40px. ∑ = 128px
+   */
+  get renderSizes(): string {
+    return `min(calc((100vh - 152px) * ${this.image.aspectRatio}), calc(100vw - 128px), ${this.image.maxIntrinsicWidth}px)`;
   }
 
   onCloseClick() {
     this.dialogRef.close();
   }
 
+  @HostListener('document:keydown.arrowright')
   onNextImageClick() {
-    // TODO:
-    console.log('display next');
+    if (this.currentImageIndex < this.images.length - 1) {
+      this.currentImageIndex++;
+      this.image = this.data.images[this.currentImageIndex];
+    }
   }
 
+  @HostListener('document:keydown.arrowleft')
   onPreviousImageClick() {
-    // TODO:
-    console.log('display previous');
+    if (this.currentImageIndex > 0) {
+      this.currentImageIndex--;
+      this.image = this.data.images[this.currentImageIndex];
+    }
   }
 }

--- a/src/app/pages/crag/crag-by-slug.query.graphql
+++ b/src/app/pages/crag/crag-by-slug.query.graphql
@@ -68,6 +68,8 @@ query CragBySlug($crag: String!) {
       id
       title
       path
+      aspectRatio
+      maxIntrinsicWidth
     }
   }
 }

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.html
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.html
@@ -17,6 +17,7 @@
           (max-width: 1439px) calc(33.33vw - 182px),
           298px
         "
+        [maxIntrinsicWidth]="image.maxIntrinsicWidth"
         [fallbackWidth]="600"
         [imageAlt]="image.title"
         (click)="onImageClick(image)"

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.html
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.html
@@ -1,7 +1,7 @@
 <div fxLayout="row wrap">
   <div
     fxFlex="50"
-    *ngFor="let image of images"
+    *ngFor="let image of images; let i = index"
     class="image-container"
     fxLayout="row"
     fxLayoutAlign="center center"
@@ -20,7 +20,7 @@
         [maxIntrinsicWidth]="image.maxIntrinsicWidth"
         [fallbackWidth]="600"
         [imageAlt]="image.title"
-        (click)="onImageClick(image)"
+        (click)="onImageClick(i)"
       ></app-responsive-image>
 
       <div class="title">{{ image.title }}</div>

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.ts
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { environment } from 'src/environments/environment';
 import { ImageFullComponent } from 'src/app/common/image-full/image-full.component';
+import { Image } from 'src/generated/graphql';
 
 @Component({
   selector: 'app-crag-gallery',
@@ -17,7 +18,7 @@ export class CragGalleryComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  onImageClick(image): void {
+  onImageClick(image: Image): void {
     this.dialog.open(ImageFullComponent, {
       width: '100vw',
       height: '100vh',

--- a/src/app/pages/crag/crag-gallery/crag-gallery.component.ts
+++ b/src/app/pages/crag/crag-gallery/crag-gallery.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { environment } from 'src/environments/environment';
 import { ImageFullComponent } from 'src/app/common/image-full/image-full.component';
-import { Image } from 'src/generated/graphql';
 
 @Component({
   selector: 'app-crag-gallery',
@@ -18,13 +17,13 @@ export class CragGalleryComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  onImageClick(image: Image): void {
+  onImageClick(index: number): void {
     this.dialog.open(ImageFullComponent, {
       width: '100vw',
       height: '100vh',
       maxWidth: '100vw',
       maxHeight: '100vh',
-      data: { image },
+      data: { images: this.images, currentImageIndex: index },
       autoFocus: false,
     });
   }

--- a/src/app/pages/crag/crag-image/crag-image.component.html
+++ b/src/app/pages/crag/crag-image/crag-image.component.html
@@ -7,6 +7,7 @@
       (max-width: 1239px) 276.97px,
       (max-width: 1439px) calc(33.33vw - 145.32px),
       334.63px"
+    [maxIntrinsicWidth]="crag.images[0].maxIntrinsicWidth"
     [imageAlt]="crag.images[0].title"
   ></app-responsive-image>
 

--- a/src/app/pages/home/latest-images/latest-image.query.graphql
+++ b/src/app/pages/home/latest-images/latest-image.query.graphql
@@ -3,6 +3,8 @@ query LatestImages($latest: Int!) {
     id
     path
     title
+    aspectRatio
+    maxIntrinsicWidth
     user {
       id
       fullName

--- a/src/app/pages/home/latest-images/latest-images.component.html
+++ b/src/app/pages/home/latest-images/latest-images.component.html
@@ -12,6 +12,7 @@
           (max-width: 1239px) 277.33px,
           (max-width: 1439px) calc(25vw - 103px),
           257px"
+        [maxIntrinsicWidth]="image.maxIntrinsicWidth"
         [imageAlt]="image.title"
       ></app-responsive-image>
 

--- a/src/app/pages/home/latest-images/latest-images.component.html
+++ b/src/app/pages/home/latest-images/latest-images.component.html
@@ -1,7 +1,7 @@
 <h2>Zadnje fotografije</h2>
 <mat-grid-list [cols]="ncols" rowHeight="1:1" gutterSize="4px" *ngIf="!loading">
-  <mat-grid-tile *ngFor="let image of latestImages">
-    <div class="wrap" (click)="onImageClick(image)">
+  <mat-grid-tile *ngFor="let image of latestImages; let i = index">
+    <div class="wrap" (click)="onImageClick(i)">
       <app-responsive-image
         [imageWidths]="[300, 600]"
         [fallbackWidth]="600"

--- a/src/app/pages/home/latest-images/latest-images.component.scss
+++ b/src/app/pages/home/latest-images/latest-images.component.scss
@@ -17,6 +17,21 @@ h2 {
   height: 100%;
   cursor: pointer;
 
+  // Comment this if we want cover effect -->
+  // display: flex;
+  // flex-direction: row;
+  // align-items: center;
+  // justify-content: center;
+  // --> cover
+
+  // Uncomment this  if we want cover effect -->
+  ::ng-deep img {
+    object-fit: cover;
+    height: 100%;
+    width: 100%;
+  }
+  // --> cover
+
   .info {
     position: absolute;
     top: 0;

--- a/src/app/pages/home/latest-images/latest-images.component.ts
+++ b/src/app/pages/home/latest-images/latest-images.component.ts
@@ -39,6 +39,7 @@ export class LatestImagesComponent implements OnInit, OnDestroy {
     private authService: AuthService
   ) {}
 
+  // TODO: very small images get upsized because of object-fit: cover. but since this will probably be changed by redesign leave as is for now...
   ngOnInit(): void {
     this.mediaObserver.asObservable().subscribe((change) => {
       switch (change[0].mqAlias) {

--- a/src/app/pages/home/latest-images/latest-images.component.ts
+++ b/src/app/pages/home/latest-images/latest-images.component.ts
@@ -78,13 +78,13 @@ export class LatestImagesComponent implements OnInit, OnDestroy {
       });
   }
 
-  onImageClick(image: Image) {
+  onImageClick(index: number) {
     this.dialog.open(ImageFullComponent, {
       width: '100vw',
       height: '100vh',
       maxWidth: '100vw',
       maxHeight: '100vh',
-      data: { image },
+      data: { images: this.latestImages, currentImageIndex: index },
       autoFocus: false,
     });
   }

--- a/src/app/shared/components/responsive-image/responsive-image.component.scss
+++ b/src/app/shared/components/responsive-image/responsive-image.component.scss
@@ -1,4 +1,5 @@
 img {
   margin: auto;
   display: block;
+  max-width: 100%;
 }

--- a/src/app/shared/components/responsive-image/responsive-image.component.scss
+++ b/src/app/shared/components/responsive-image/responsive-image.component.scss
@@ -1,10 +1,4 @@
 img {
-  object-fit: cover;
-  height: 100%;
-  width: 100%;
+  margin: auto;
   display: block;
-}
-
-picture {
-  height: 100%;
 }

--- a/src/app/shared/components/responsive-image/responsive-image.component.ts
+++ b/src/app/shared/components/responsive-image/responsive-image.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { environment } from 'src/environments/environment';
 
 @Component({
@@ -6,7 +6,7 @@ import { environment } from 'src/environments/environment';
   templateUrl: './responsive-image.component.html',
   styleUrls: ['./responsive-image.component.scss'],
 })
-export class ResponsiveImageComponent implements OnInit {
+export class ResponsiveImageComponent implements OnChanges {
   @Input() imageWidths: number[];
   @Input() fallbackWidth: number;
   @Input() imagePath: string;
@@ -22,7 +22,7 @@ export class ResponsiveImageComponent implements OnInit {
 
   constructor() {}
 
-  ngOnInit(): void {
+  ngOnChanges(): void {
     this.avifSrcset = this.generateSrcset(this.imageWidths, 'avif');
     this.webpSrcset = this.generateSrcset(this.imageWidths, 'webp');
     this.jpgSrcset = this.generateSrcset(this.imageWidths, 'jpg');

--- a/src/app/shared/components/responsive-image/responsive-image.component.ts
+++ b/src/app/shared/components/responsive-image/responsive-image.component.ts
@@ -12,6 +12,7 @@ export class ResponsiveImageComponent implements OnInit {
   @Input() imagePath: string;
   @Input() renderSizes: string;
   @Input() imageAlt: string;
+  @Input() maxIntrinsicWidth: number;
 
   storageUrl = environment.storageUrl;
 
@@ -28,12 +29,20 @@ export class ResponsiveImageComponent implements OnInit {
   }
 
   private generateSrcset(imageWidths: number[], format: string) {
-    return imageWidths
-      .reduce(
-        (prev: string, size: number) =>
-          `${prev}${this.storageUrl}/images/${size}/${this.imagePath}.${format} ${size}w, `,
-        ''
-      )
-      .slice(0, -2);
+    let srcset = '';
+    imageWidths.every((width) => {
+      // If the 'requested' image size is not available
+      if (width > this.maxIntrinsicWidth) {
+        srcset += `${this.storageUrl}/images/${width}/${this.imagePath}.${format} ${this.maxIntrinsicWidth}w, `; // this is best of what we have to offer
+        return false; // break loop, because larger sizes are then also unavailable
+      }
+
+      srcset += `${this.storageUrl}/images/${width}/${this.imagePath}.${format} ${width}w, `;
+      return true;
+    });
+
+    srcset = srcset.slice(0, -2); // remove last space and comma
+
+    return srcset;
   }
 }


### PR DESCRIPTION
If PR https://github.com/plezanje-net/web/pull/369 is merged before this, make sure that you uncomment latest-images component on homepage before testing.

Test this with: https://github.com/plezanje-net/api/pull/104

Full page view of images is now fixed.

To test this, click through different images, then resize browser window to see that they are always correctly displayed, which is:
- Take up as much space as possible, leaving space for close/prev/next buttons and for caption at the bottom.
- Never upscale the image. 
- Image+Caption should be centred vertically and horizontally.
(If you'd like to easily inspect the layout, you can uncomment the coloured backgrounds from image-full-component.scss)

Also click through other image instances on the page to see nothing else broke. :) 

Buttons for next/previous navigation are working now.
You can also use left and right keyboard arrows. 
There is a slight flicker in some cases, where sizes of adjacent images vary.
A better approach for some future improvement would be to use a slider for image 'switching'.
