### PR TITLE
Fix diff vote disabled visibility bug & more

### DIFF
--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
@@ -144,6 +144,7 @@
         emptyText="Ne predlagaj ocene"
         [gradingSystemId]="route.value.defaultGradingSystemId"
         [noHint]="true"
+        [focusDifficulty]="route.value.difficulty"
       ></app-grade-select>
     </div>
 

--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -36,25 +36,13 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
   constructor(public activityFormService: ActivityFormService) {}
 
   ngOnInit(): void {
+    // Should disable possibility to vote on route difficulty if ascent type not a tick and if ascent visibility publish type is not public (public, log)
     this.route.controls.publish.valueChanges
       .pipe(takeUntil(this.destroy$))
-      .subscribe((publish: PublishOptionsEnum) => {
-        const votedDifficultyControl = this.route.controls.votedDifficulty;
-
-        if (
-          publish === PublishOptionsEnum.private &&
-          !votedDifficultyControl.disabled
-        ) {
-          votedDifficultyControl.reset();
-          votedDifficultyControl.disable();
-        } else {
-          if (votedDifficultyControl.disabled) {
-            votedDifficultyControl.enable();
-          }
-        }
+      .subscribe(() => {
+        this.activityFormService.conditionallyDisableVotedDifficultyInputs();
       });
 
-    // Should disable possibility to vote on route if ascent type not a tick.
     const ascentTypeSelected = this.route.get('ascentType').value;
     this.setAscentTypeTriggerValue(ascentTypeSelected);
 

--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -68,11 +68,14 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
       (at) => at.value === ascentTypeSelected && at.tick
     );
     if (isTick) {
-      this.route.get('votedDifficulty').addValidators(Validators.required);
+      // votedDifficulty might be didabled, and disabled fields are skipped from validation. Thus need to add validation function to formGroup level instead
+      this.route.setValidators((formGroup) =>
+        Validators.required(formGroup.get('votedDifficulty'))
+      );
     } else {
-      this.route.get('votedDifficulty').clearValidators();
+      this.route.clearValidators();
     }
-    this.route.get('votedDifficulty').updateValueAndValidity();
+    this.route.updateValueAndValidity();
   }
 
   /**

--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -43,16 +43,7 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
         this.activityFormService.conditionallyDisableVotedDifficultyInputs();
       });
 
-    const ascentTypeSelected = this.route.get('ascentType').value;
-    this.setAscentTypeTriggerValue(ascentTypeSelected);
-
-    // If a route is a project then a vote on difficulty should always be cast (we need to get the base grade from the user ticking the proj)
-    if (this.route.get('isProject').value) {
-      this.conditionallyRequireVotedDifficulty(ascentTypeSelected);
-    }
-    // TODO: above few lines (from atSelected) actually do nothing, because atSel is null when route is initialized. And when ascentType field is first populated, the bellow observer gets called
-
-    // Revalidate stuff when ascentType is changed
+    // Revalidate stuff when ascentType is changed  (also triggered on load when ascentType fields are populated)
     this.route
       .get('ascentType')
       .valueChanges.pipe(takeUntil(this.destroy$))

--- a/src/app/activity/forms/activity-form/activity-form.component.ts
+++ b/src/app/activity/forms/activity-form/activity-form.component.ts
@@ -145,13 +145,15 @@ export class ActivityFormComponent implements OnInit, OnDestroy {
           const routeTrTicked = trTickedRoutes.has(routeId);
           route.get('trTicked').setValue(routeTrTicked);
 
-          // Set default value for ascentType based on user's log history (might get changed rihgt away with revalidateAT, but it's a good first guess anyway)
-          route.patchValue(
-            {
-              ascentType: routeTicked ? 'repeat' : 'redpoint',
-            },
-            { emitEvent: false }
-          );
+          // If not already set, set default value for ascentType based on user's log history (might get changed rihgt away with revalidateAT, but it's a good first guess anyway)
+          if (!route.get('ascentType').value) {
+            route.patchValue(
+              {
+                ascentType: routeTicked ? 'repeat' : 'redpoint',
+              },
+              { emitEvent: false }
+            );
+          }
         });
 
         this.activityFormService.revalidateAscentTypes();

--- a/src/app/activity/forms/activity-form/activity-form.service.ts
+++ b/src/app/activity/forms/activity-form/activity-form.service.ts
@@ -1,6 +1,9 @@
 import { Injectable } from '@angular/core';
 import { FormArray, FormControl, FormGroup } from '@angular/forms';
-import { ASCENT_TYPES } from 'src/app/common/activity.constants';
+import {
+  ASCENT_TYPES,
+  PublishOptionsEnum,
+} from 'src/app/common/activity.constants';
 
 @Injectable({
   providedIn: 'root',
@@ -190,8 +193,14 @@ export class ActivityFormService {
     return new FormGroup(formGroupData);
   }
 
+  /**
+   * Go through all distinct routes being logged.
+   * For each of them enable voted difficulty input if:
+   *  - it is the first instance with ascent type that is a tick AND
+   *  - ascent publish visibility is set to one of the public types (log, public)
+   * Disable it in all other cases.
+   */
   conditionallyDisableVotedDifficultyInputs() {
-    // Go through all distinct routes being logged. For each of them enable voted difficulty input if it is the first instance with ascent type that is a tick and disable it in all other cases.
     this.distinctRouteIds.forEach((routeId) => {
       let someVDIEnabled = false;
       this.routesBeingLoggedFormArray.controls
@@ -199,9 +208,12 @@ export class ActivityFormService {
           (routeFormGroup) => routeFormGroup.get('routeId').value === routeId
         )
         .forEach((routeFormGroup) => {
+          // One can vote on difficulty only if this is a tick and a public log. And only on one ascent if multiple of same route being logged at once.
           if (
             this.tickAscentTypes.has(routeFormGroup.get('ascentType').value) &&
-            !someVDIEnabled
+            !someVDIEnabled &&
+            (routeFormGroup.get('publish').value === PublishOptionsEnum.log ||
+              routeFormGroup.get('publish').value === PublishOptionsEnum.public)
           ) {
             someVDIEnabled = true;
             routeFormGroup.get('votedDifficulty').enable({ emitEvent: false });

--- a/src/app/shared/components/grade-select/grade-select.component.html
+++ b/src/app/shared/components/grade-select/grade-select.component.html
@@ -1,6 +1,6 @@
 <mat-form-field class="w-100" [class.no-hint]="noHint">
   <mat-label>{{ label }}</mat-label>
-  <mat-select [formControl]="control">
+  <mat-select [formControl]="control" (opened)="onOpened()">
     <mat-option>
       <ngx-mat-select-search
         [formControl]="gradeFilterControl"

--- a/src/app/shared/components/grade-select/grade-select.component.ts
+++ b/src/app/shared/components/grade-select/grade-select.component.ts
@@ -21,6 +21,7 @@ export class GradeSelectComponent implements OnInit, OnChanges {
   @Input() control: FormControl;
   @Input() gradingSystemId: string;
   @Input() noHint = false;
+  @Input() focusDifficulty = null;
 
   allGrades: GradingSystemsQuery['gradingSystems'][0]['grades'];
   filteredGrades: GradingSystemsQuery['gradingSystems'][0]['grades'];
@@ -41,6 +42,26 @@ export class GradeSelectComponent implements OnInit, OnChanges {
 
       this.init();
     }
+  }
+
+  /**
+   * When select is opened, scroll to the grade that might be passed in as a focus difficulty - that is the route's current grade for example
+   */
+  onOpened() {
+    if (!this.focusDifficulty) return; // e.g. if project, there is no focus difficulty
+
+    this.gradingSystemService
+      .diffToGrade(this.focusDifficulty, this.gradingSystemId, false)
+      .then((grade) => {
+        const allOptions = document.querySelectorAll('mat-option');
+        for (let i = 0; i < allOptions.length; i++) {
+          const goBack = Math.min(i, 3); // deduct 3 to get the target in the center (5 are displayed)
+          if ((<HTMLElement>allOptions[i]).innerText === grade.name) {
+            allOptions[i - goBack].scrollIntoView();
+            break;
+          }
+        }
+      });
   }
 
   init() {


### PR DESCRIPTION
1
Fixes disabling difficulty vote when changing visibility

To test this: 
Log a route or many routes and try out different ascent type and publish type selections, changing them in different order. 
Observe that difficulty vote gets disabled as it should now. 

There is one thing to consider though: what are publish types that let user cast a vote? Now they are set up to be: 'public' and 'log'. What is 'log' pt anyway?

This might all be unimportant if we decide to let the user vote in all publish types...

closes #330

2
Fixes resetting ascentTypes on date change. Now keeps them as first set.

To test this:
Start logging some routes. Set ascent types. Change the date. Observe that the selected ascentTypes only change if the date change made them impossible.
Try also projects, and multiple instances of same route.
 
closes #331

3
Fixes a bug where one could log a project and not cast a difficulty vote by 'tricking' the validation with changing the publish type to private.
To test this:
Log a project, select one of the tick ascent types, change publish type to some private type and make sure that the diff vote gets disabled. Observe that the form is invalid and cannot be posted.
Before this test BE validation of this same thing with: https://github.com/plezanje-net/api/pull/108

closes #340 

4
Scrolls mat-select or we could say 'focuses' on the route's current grade when diff vote dropdown is opened.
To test: Log a route, open the diff vote input, observe that the list is 'moved' to the  route's current grade

closes #341 