### PR TITLE
Votes on all logs possible

### DIFF
--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
@@ -73,7 +73,9 @@
       <mat-form-field class="no-hint" fxFlex="50">
         <mat-label>Vrsta vzpona</mat-label>
         <mat-select formControlName="ascentType">
-          <mat-select-trigger>{{ ascentTypeTrigger }}</mat-select-trigger>
+          <mat-select-trigger>{{
+            mapAscentTypeValueToFullLabel(route.value.ascentType)
+          }}</mat-select-trigger>
           <ng-container *ngFor="let type of nonTopRopeAscentTypes">
             <mat-option
               *ngIf="logPossibleEver(type.value)"

--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.ts
@@ -2,7 +2,6 @@ import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup, Validators } from '@angular/forms';
 import {
   ASCENT_TYPES,
-  PublishOptionsEnum,
   PUBLISH_OPTIONS,
 } from '../../../../common/activity.constants';
 import { Crag } from 'src/generated/graphql';
@@ -29,8 +28,6 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
     (ascentType) => !ascentType.topRope
   );
 
-  ascentTypeTrigger: string;
-
   publishOptions = PUBLISH_OPTIONS;
 
   constructor(public activityFormService: ActivityFormService) {}
@@ -43,7 +40,7 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
         this.activityFormService.conditionallyDisableVotedDifficultyInputs();
       });
 
-    // Revalidate stuff when ascentType is changed  (also triggered on load when ascentType fields are populated)
+    // Revalidate stuff when ascentType is changed (also triggered on load when ascentType fields are populated)
     this.route
       .get('ascentType')
       .valueChanges.pipe(takeUntil(this.destroy$))
@@ -51,8 +48,6 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
         this.activityFormService.revalidateAscentTypes();
         this.activityFormService.conditionallyDisableVotedDifficultyInputs();
         this.activityFormService.conditionallyDisableVotedStarRatingInputs();
-
-        this.setAscentTypeTriggerValue(ascentType);
 
         if (this.route.get('isProject').value) {
           this.conditionallyRequireVotedDifficulty(ascentType);
@@ -92,17 +87,18 @@ export class ActivityFormRouteComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Set trigger value for ascent type select (so it includes toprope so there can be no confusion)
+   * Map trigger value for ascent type select (so it includes toprope so there can be no confusion)
    */
-  setAscentTypeTriggerValue(ascentTypeSelected: string) {
+  mapAscentTypeValueToFullLabel(ascentTypeSelected: string) {
     const ascentType = ASCENT_TYPES.find(
-      (at) => at.value == ascentTypeSelected
+      (at) => at.value === ascentTypeSelected
     );
 
     if (ascentType != null) {
-      this.ascentTypeTrigger =
-        ascentType.label + (ascentType.topRope ? ' (top rope)' : '');
+      return ascentType.label + (ascentType.topRope ? ' (top rope)' : '');
     }
+
+    return ascentType;
   }
 
   ngOnDestroy(): void {

--- a/src/app/activity/forms/activity-form/activity-form.component.html
+++ b/src/app/activity/forms/activity-form/activity-form.component.html
@@ -119,6 +119,12 @@
             (move)="moveRoute(index, $event)"
           ></app-activity-form-route>
         </div>
+
+        <div class="footnote">
+          *Tvoji predlogi o težavnosti in lepoti smeri bodo v vsakem primeru
+          javno objavljeni (v kolikor jih podaš) ne glede na izbrano vidnost
+          zabeleženih vzponov.
+        </div>
       </div>
     </div>
   </div>

--- a/src/app/activity/forms/activity-form/activity-form.component.scss
+++ b/src/app/activity/forms/activity-form/activity-form.component.scss
@@ -8,7 +8,7 @@
   border-bottom: 1px solid rgba(0, 0, 0, 0.12);
   padding-bottom: 16px;
   margin-bottom: 8px;
-  &:last-child {
+  &:nth-last-child(2) {
     border-bottom: none;
   }
 }
@@ -23,4 +23,9 @@ button {
     font-size: 13px;
     margin: 8px 28px;
   }
+}
+
+.footnote {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 10.5px;
 }

--- a/src/app/activity/forms/activity-form/activity-form.service.ts
+++ b/src/app/activity/forms/activity-form/activity-form.service.ts
@@ -195,9 +195,7 @@ export class ActivityFormService {
 
   /**
    * Go through all distinct routes being logged.
-   * For each of them enable voted difficulty input if:
-   *  - it is the first instance with ascent type that is a tick AND
-   *  - ascent publish visibility is set to one of the public types (log, public)
+   * For each of them enable voted difficulty input if it is the first instance with ascent type that is a tick.
    * Disable it in all other cases.
    */
   conditionallyDisableVotedDifficultyInputs() {
@@ -226,7 +224,7 @@ export class ActivityFormService {
   }
 
   conditionallyDisableVotedStarRatingInputs() {
-    // Go through all distinct routes being logged. For each of them enable voted star rating input if it is the first instance with ascent type that is a tick and disable it in all other cases.
+    // Go through all distinct routes being logged. For each of them enable voted star rating input if it is the first instance of the route being logged and disable it in all other cases.
     this.distinctRouteIds.forEach((routeId) => {
       let someVSRIEnabled = false;
       this.routesBeingLoggedFormArray.controls
@@ -234,10 +232,7 @@ export class ActivityFormService {
           (routeFormGroup) => routeFormGroup.get('routeId').value === routeId
         )
         .forEach((routeFormGroup) => {
-          if (
-            this.tickAscentTypes.has(routeFormGroup.get('ascentType').value) &&
-            !someVSRIEnabled
-          ) {
+          if (!someVSRIEnabled) {
             someVSRIEnabled = true;
             routeFormGroup.get('votedStarRating').enable({ emitEvent: false });
           } else {

--- a/src/app/activity/forms/activity-form/activity-form.service.ts
+++ b/src/app/activity/forms/activity-form/activity-form.service.ts
@@ -208,12 +208,10 @@ export class ActivityFormService {
           (routeFormGroup) => routeFormGroup.get('routeId').value === routeId
         )
         .forEach((routeFormGroup) => {
-          // One can vote on difficulty only if this is a tick and a public log. And only on one ascent if multiple of same route being logged at once.
+          // One can vote on difficulty only if this is a tick. And only on one ascent if multiple of same route being logged at once.
           if (
             this.tickAscentTypes.has(routeFormGroup.get('ascentType').value) &&
-            !someVDIEnabled &&
-            (routeFormGroup.get('publish').value === PublishOptionsEnum.log ||
-              routeFormGroup.get('publish').value === PublishOptionsEnum.public)
+            !someVDIEnabled
           ) {
             someVDIEnabled = true;
             routeFormGroup.get('votedDifficulty').enable({ emitEvent: false });

--- a/src/app/pages/changelog/changelog.component.html
+++ b/src/app/pages/changelog/changelog.component.html
@@ -9,15 +9,15 @@
     <div class="date">12. 5. 2022</div>
     <h2>Glasovanje o težavnosti in lepoti smeri</h2>
     <p>
-      Mnenje o težavnosti smeri (predlog ocene) odslej lahko podaš tudi kadar
+      Mnenje o težavnosti smeri (predlog ocene) lahko odslej podaš tudi kadar
       zabeležiš vzpon z vidnostjo 'samo zame' ali 'samo za prijatelje'.
     </p>
     <p>
-      Mnenje o lepoti smeri (zvezdice) lahko odslej oddaš tudi kadar zabeležiš
+      Mnenje o lepoti smeri (zvezdice) lahko odslej podaš tudi kadar zabeležiš
       neuspešen vzpon v smeri.
     </p>
     <p>
-      Tvoje mnenje o težavnosti smeri in tvoje mnenje o lepoti smere bosta vedno
+      Tvoje mnenje o težavnosti smeri in tvoje mnenje o lepoti smeri bosta vedno
       javno objavljena, ne glede na izbrano vidnost zabeleženega vzpona.
     </p>
   </mat-card>

--- a/src/app/pages/changelog/changelog.component.html
+++ b/src/app/pages/changelog/changelog.component.html
@@ -6,6 +6,22 @@
 
 <div class="container mt-16">
   <mat-card>
+    <div class="date">12. 5. 2022</div>
+    <h2>Glasovanje o težavnosti in lepoti smeri</h2>
+    <p>
+      Mnenje o težavnosti smeri (predlog ocene) odslej lahko podaš tudi kadar
+      zabeležiš vzpon z vidnostjo 'samo zame' ali 'samo za prijatelje'.
+    </p>
+    <p>
+      Mnenje o lepoti smeri (zvezdice) lahko odslej oddaš tudi kadar zabeležiš
+      neuspešen vzpon v smeri.
+    </p>
+    <p>
+      Tvoje mnenje o težavnosti smeri in tvoje mnenje o lepoti smere bosta vedno
+      javno objavljena, ne glede na izbrano vidnost zabeleženega vzpona.
+    </p>
+  </mat-card>
+  <mat-card>
     <div class="date">12. 4. 2022</div>
     <h2>Preverjanje tipov vzponov</h2>
     <p>

--- a/src/app/shared/components/grade-select/grade-select.component.ts
+++ b/src/app/shared/components/grade-select/grade-select.component.ts
@@ -50,6 +50,8 @@ export class GradeSelectComponent implements OnInit, OnChanges {
   onOpened() {
     if (!this.focusDifficulty) return; // e.g. if project, there is no focus difficulty
 
+    if (this.control.value) return;
+
     this.gradingSystemService
       .diffToGrade(this.focusDifficulty, this.gradingSystemId, false)
       .then((grade) => {


### PR DESCRIPTION
1.
Make voting on route difficulty possible on all ascent types (also on non-public ascents).
Test: Try logging a route, choose publish type 'private'. Observe that voting on difficulty is possible.

2.
Fix a bug on mat-select-trigger.
Test: First observe the bug on master: start logging a route, choose ascent type e.g. 'repeat', duplicate the route and see that ascent type is not filled in although it is possible and should be copied from original. Switch to this branch and see that the same works now.

3.
Minor change in difficulty vote input behaviour. It is set to 'scroll' into view only when no difficulty is selected.
Test: Start logging a route. Open difficulty vote input and see that the input 'scrolls' to current route difficulty. Choose some difficulty. Open the input again and observe that it doesn't scroll again.

4.
OPTIONAL
This is my suggestion and can be reverted if we do not agree on it.
I made voting about beauty (star rating) possible for all ascent types, even for non-tick ones. 
I believe that one only needs to try a route to be able to tell if it is onestar, twostar, nostar...
Test: Start logging an ascent, choose a non-tick ascent type. Observe that star rating vote is enabled.


closes #352 