### PR TITLE
Add ascent counts to route page and to route list (crag) page.

### DIFF
--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
@@ -156,28 +156,22 @@
             Nič posebnega
           </span>
           <span *ngIf="route.controls.votedStarRating.value == 1"
-            ><mat-icon>star_border</mat-icon>
-            <span class="icon-text">Lepa</span>
-          </span>
+            ><mat-icon>star_border</mat-icon
+            ><span class="icon-text">Lepa</span></span
+          >
           <span *ngIf="route.controls.votedStarRating.value == 2"
             ><mat-icon>star</mat-icon>
             <span class="icon-text">Čudovita</span>
           </span>
         </mat-select-trigger>
         <mat-option [value]="null">Ne predlagaj lepote</mat-option>
-        <mat-option [value]="0"><span></span>Nič posebnega</mat-option>
-        <mat-option [value]="1"
-          ><span
-            ><mat-icon>star_border</mat-icon>
-            <span class="icon-text">Lepa</span>
-          </span></mat-option
-        >
-        <mat-option [value]="2"
-          ><span
-            ><mat-icon>star</mat-icon
-            ><span class="icon-text">Čudovita</span></span
-          ></mat-option
-        >
+        <mat-option [value]="0">Nič posebnega</mat-option>
+        <mat-option [value]="1">
+          <span><mat-icon>star_border</mat-icon>Lepa</span>
+        </mat-option>
+        <mat-option [value]="2">
+          <span><mat-icon>star</mat-icon>Čudovita</span>
+        </mat-option>
       </mat-select>
     </mat-form-field>
   </div>

--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.scss
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.scss
@@ -9,26 +9,29 @@
   z-index: 1;
 }
 
+mat-option {
+  span {
+    display: flex;
+    align-items: center;
+  }
+
+  // icon inside mat-select should be smaller
+  mat-icon.mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+  }
+}
+
+// mat trigger label is handled differently because flex somehow increases row height...
 .mat-select.star-rating {
   .mat-icon {
     font-size: 16px;
     width: 16px;
-    width: 16px;
+    height: 16px;
     position: absolute;
-    bottom: -5px;
-  }
-  span.icon-text {
-    margin-left: 20px;
-  }
-}
-
-.mat-option {
-  .mat-icon {
-    font-size: 16px;
-    width: 16px;
-    width: 16px;
-    position: absolute;
-    bottom: 5px;
+    bottom: 3px;
   }
   span.icon-text {
     margin-left: 20px;

--- a/src/app/activity/forms/activity-form/activity-form.component.html
+++ b/src/app/activity/forms/activity-form/activity-form.component.html
@@ -127,7 +127,7 @@
 
         <div class="footnote">
           *Tvoji predlogi o težavnosti in lepoti smeri bodo v vsakem primeru
-          javno objavljeni (v kolikor jih podaš) ne glede na izbrano vidnost
+          javno objavljeni (če jih podaš) ne glede na izbrano vidnost
           zabeleženih vzponov.
         </div>
       </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,8 @@ import { LayoutService } from './services/layout.service';
 import { filter } from 'rxjs/operators';
 import * as _ from 'lodash';
 import { Subscription, take } from 'rxjs';
+import { DomSanitizer } from '@angular/platform-browser';
+import { MatIconRegistry } from '@angular/material/icon';
 
 declare let gtag: Function;
 
@@ -27,8 +29,17 @@ export class AppComponent implements OnInit, OnDestroy {
     private authService: AuthService,
     private dialog: MatDialog,
     private router: Router,
-    private layoutService: LayoutService
-  ) {}
+    private layoutService: LayoutService,
+    private matIconRegistry: MatIconRegistry,
+    private domSanitizer: DomSanitizer
+  ) {
+    this.matIconRegistry.addSvgIcon(
+      'multipitch',
+      this.domSanitizer.bypassSecurityTrustResourceUrl(
+        '../assets/icons/multipitch.svg'
+      )
+    );
+  }
 
   ngOnInit(): void {
     this.authService.initialize();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -54,7 +54,6 @@ import { CragCommentsComponent } from './pages/crag/crag-comments/crag-comments.
 import {
   DateAdapter,
   MatNativeDateModule,
-  MAT_DATE_FORMATS,
   MAT_DATE_LOCALE,
   NativeDateAdapter,
 } from '@angular/material/core';
@@ -96,6 +95,7 @@ registerLocaleData(localeSl);
 import * as Sentry from '@sentry/angular';
 import { Router } from '@angular/router';
 import { ChangelogComponent } from './pages/changelog/changelog.component';
+import { SortableHeaderFieldComponent } from './common/sortable-header-field/sortable-header-field.component';
 
 const formFieldAppearance: MatFormFieldDefaultOptions = {
   appearance: 'fill',
@@ -168,6 +168,7 @@ class CustomDateAdapter extends NativeDateAdapter {
     AlpinismComponent,
     AboutComponent,
     ChangelogComponent,
+    SortableHeaderFieldComponent,
   ],
   imports: [
     BrowserModule,

--- a/src/app/common/distribution-chart/distribution-chart.component.scss
+++ b/src/app/common/distribution-chart/distribution-chart.component.scss
@@ -11,7 +11,7 @@
 
 .distribution-bar {
   height: 8px;
-  background-color: white;
+  background-color: transparent;
 }
 
 .distribution-bar-inner {

--- a/src/app/common/sortable-header-field/sortable-header-field.component.html
+++ b/src/app/common/sortable-header-field/sortable-header-field.component.html
@@ -1,0 +1,30 @@
+<div
+  [class.active]="
+    sortIndication === 'highlight' && currentlySortedField === field
+  "
+  [class.center]="centered"
+>
+  <ng-container *ngIf="label">
+    {{ label }}
+  </ng-container>
+  <mat-icon *ngIf="icon">
+    {{ icon }}
+  </mat-icon>
+  <mat-icon *ngIf="svgIcon" [svgIcon]="svgIcon"> </mat-icon>
+  <mat-icon
+    *ngIf="sortIndication === 'arrows'"
+    [class.active]="
+      currentlySortedField === field && currentSortDirection === 1
+    "
+    class="sort-arrow"
+    >north</mat-icon
+  >
+  <mat-icon
+    *ngIf="sortIndication === 'arrows'"
+    [class.active]="
+      currentlySortedField == field && currentSortDirection === -1
+    "
+    class="sort-arrow"
+    >south</mat-icon
+  >
+</div>

--- a/src/app/common/sortable-header-field/sortable-header-field.component.html
+++ b/src/app/common/sortable-header-field/sortable-header-field.component.html
@@ -10,7 +10,7 @@
   <mat-icon *ngIf="icon">
     {{ icon }}
   </mat-icon>
-  <mat-icon *ngIf="svgIcon" [svgIcon]="svgIcon"> </mat-icon>
+  <mat-icon *ngIf="svgIcon" [svgIcon]="svgIcon"></mat-icon>
   <mat-icon
     *ngIf="sortIndication === 'arrows'"
     [class.active]="

--- a/src/app/common/sortable-header-field/sortable-header-field.component.scss
+++ b/src/app/common/sortable-header-field/sortable-header-field.component.scss
@@ -4,7 +4,6 @@ div {
   cursor: pointer;
   display: flex;
   align-items: center;
-  line-height: 24px;
 }
 
 .center {

--- a/src/app/common/sortable-header-field/sortable-header-field.component.scss
+++ b/src/app/common/sortable-header-field/sortable-header-field.component.scss
@@ -1,0 +1,26 @@
+@import "../../../styles/colors.scss";
+
+div {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  line-height: 24px;
+}
+
+.center {
+  justify-content: center;
+}
+
+mat-icon.sort-arrow {
+  &:last-child {
+    margin-left: -6px;
+  }
+
+  font-size: 12px;
+  width: 12px;
+  height: 12px;
+}
+
+.active {
+  color: $primary;
+}

--- a/src/app/common/sortable-header-field/sortable-header-field.component.ts
+++ b/src/app/common/sortable-header-field/sortable-header-field.component.ts
@@ -1,0 +1,21 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-sortable-header-field',
+  templateUrl: './sortable-header-field.component.html',
+  styleUrls: ['./sortable-header-field.component.scss'],
+})
+export class SortableHeaderFieldComponent implements OnInit {
+  @Input() field: string;
+  @Input() label?: string;
+  @Input() icon?: string;
+  @Input() svgIcon?: string;
+  @Input() centered = false;
+  @Input() sortIndication: 'highlight' | 'arrows';
+  @Input() currentSortDirection?: number;
+  @Input() currentlySortedField: string;
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/src/app/pages/changelog/changelog.component.html
+++ b/src/app/pages/changelog/changelog.component.html
@@ -6,6 +6,37 @@
 
 <div class="container mt-16">
   <mat-card>
+    <div class="date">4. 6. 2022</div>
+    <h2>
+      Število vzponov, lepota smeri in poljubni stolpci ter razvrščanje in
+      filtriranje smeri v seznamu
+    </h2>
+    <p>Na seznam smeri smo dodali naslednje podatke o smereh:</p>
+    <ul>
+      <li>število vseh uspešnih vzponov v smeri,</li>
+      <li>število vseh poskusov v smeri (uspešnih in neuspešnih),</li>
+      <li>
+        število vseh plezalcev, ki so (uspešno ali neuspešno) plezali smer,
+      </li>
+      <li>lepota smeri (zvezdice).</li>
+    </ul>
+    <p>
+      Stolpce seznama lahko poljubno prikažeš ali skriješ tako, da jih označiš
+      ali odznačiš v spustnem seznamu.
+    </p>
+    <p>
+      Seznam smeri lahko razvrstiš po kateremkoli stolpcu s klikom na ime
+      stolpca (na večjih zaslonih) ali z izbiro iz spustnega seznama (na manjših
+      zaslonih).
+    </p>
+    <p>
+      Na večjih plezališčih, kjer so seznami smeri dolgi, lahko iskano smer
+      odslej hitro poiščeš tako, da del imena smeri vneseš v iskalno polje nad
+      seznamom.
+    </p>
+  </mat-card>
+
+  <mat-card>
     <div class="date">12. 5. 2022</div>
     <h2>Glasovanje o težavnosti in lepoti smeri</h2>
     <p>
@@ -21,6 +52,7 @@
       javno objavljena, ne glede na izbrano vidnost zabeleženega vzpona.
     </p>
   </mat-card>
+
   <mat-card>
     <div class="date">12. 4. 2022</div>
     <h2>Preverjanje tipov vzponov</h2>

--- a/src/app/pages/changelog/changelog.component.scss
+++ b/src/app/pages/changelog/changelog.component.scss
@@ -41,3 +41,13 @@ img {
     color: $colors-green;
   }
 }
+
+ul {
+  margin-bottom: 12px;
+  margin-top: -4px;
+  li {
+    list-style: circle;
+    list-style-position: inside;
+    padding-left: 16px;
+  }
+}

--- a/src/app/pages/crag/crag-by-slug.query.graphql
+++ b/src/app/pages/crag/crag-by-slug.query.graphql
@@ -49,6 +49,11 @@ query CragBySlug($crag: String!) {
           number
           height
         }
+        nrTicks
+        nrTries
+        nrClimbers
+        position
+        starRating
       }
       bouldersOnly
     }

--- a/src/app/pages/crag/crag-route-preview/crag-route-preview.component.html
+++ b/src/app/pages/crag/crag-route-preview/crag-route-preview.component.html
@@ -1,11 +1,14 @@
-<div #container>
-  <container *ngIf="!gradeDistributionLoading && gradeDistribution.length">
-    <h3>Ocene uporabnikov</h3>
+<div #container class="preview-container">
+  <div
+    *ngIf="!gradeDistributionLoading && gradeDistribution.length"
+    class="pb-8"
+  >
+    <h4>Ocene uporabnikov</h4>
     <app-distribution-chart
       [distribution]="gradeDistribution"
       (onViewInit)="routeGradesInitialized = true"
     ></app-distribution-chart>
-  </container>
+  </div>
   <app-route-comments
     *ngIf="!routeCommentsLoading && routeComments.length"
     [comments]="routeComments"

--- a/src/app/pages/crag/crag-route-preview/crag-route-preview.component.scss
+++ b/src/app/pages/crag/crag-route-preview/crag-route-preview.component.scss
@@ -1,0 +1,16 @@
+@import "../../../../styles/variables.scss";
+
+h4 {
+  font-size: 14px;
+  font-weight: 500;
+  color: $gray;
+  margin: 16px 0 8px 0;
+}
+
+.preview-container {
+  padding: 0 42px 16px 42px;
+  div {
+    // to avoid collapsing margins
+    overflow: auto;
+  }
+}

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -1,9 +1,6 @@
 <ng-container *ngIf="!loading">
   <div class="select-columns-and-sort-wrap mt-16">
-    <mat-form-field
-      class="no-hint"
-      [ngClass]="{ 'max-half': availableWidth >= tableWidth }"
-    >
+    <mat-form-field class="no-hint">
       <mat-label>Prikaži stolpce</mat-label>
       <mat-select
         [(value)]="shownColumns"
@@ -62,377 +59,245 @@
         </ng-container>
       </mat-select>
     </mat-form-field>
+
+    <mat-form-field class="no-hint">
+      <mat-label>Išči po seznamu</mat-label>
+      <input matInput autofocus [formControl]="search" autocomplete="off" />
+    </mat-form-field>
   </div>
 
   <div *ngFor="let sector of sectors; let sectorIndex = index">
-    <h3 *ngIf="sector.label || sector.name" class="sector-heading">
-      {{ sector.label }}
-      <span>{{ sector.name != "" ? " - " + sector.name : "" }}</span>
-    </h3>
+    <ng-container *ngIf="sector.someRoutesShown">
+      <h3 *ngIf="sector.label || sector.name" class="sector-heading">
+        {{ sector.label }}
+        <span>{{ sector.name != "" ? " - " + sector.name : "" }}</span>
+      </h3>
 
-    <!-- Table view -->
-    <table *ngIf="availableWidth >= tableWidth" class="shadow mt-16">
-      <thead>
-        <tr>
-          <th class="checkbox">
-            <app-sortable-header-field
-              field="position"
-              label="#"
-              [currentlySortedField]="sector.sortedField"
-              sortIndication="highlight"
-              [centered]="true"
-              (click)="onSortableHeaderClick(sectorIndex, 'position')"
-            ></app-sortable-header-field>
-          </th>
+      <!-- Table view -->
+      <table *ngIf="availableWidth >= tableWidth" class="shadow mt-16">
+        <thead>
+          <tr>
+            <th class="checkbox">
+              <app-sortable-header-field
+                field="position"
+                label="#"
+                [currentlySortedField]="sector.sortedField"
+                sortIndication="highlight"
+                [centered]="true"
+                (click)="onSortableHeaderClick(sectorIndex, 'position')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="name"
-            *ngIf="shownColumns.includes('name')"
-            [ngStyle]="{ 'min-width.px': allColumns.name.width }"
-          >
-            <app-sortable-header-field
-              field="name"
-              [label]="allColumns.name.tableLabel"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="arrows"
-              (click)="onSortableHeaderClick(sectorIndex, 'name')"
-            ></app-sortable-header-field>
-          </th>
+            <th
+              class="name"
+              *ngIf="shownColumns.includes('name')"
+              [ngStyle]="{ 'min-width.px': allColumns.name.width }"
+            >
+              <app-sortable-header-field
+                field="name"
+                [label]="allColumns.name.tableLabel"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="arrows"
+                (click)="onSortableHeaderClick(sectorIndex, 'name')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="length"
-            *ngIf="!sector.bouldersOnly && shownColumns.includes('length')"
-            [ngStyle]="{ 'width.px': allColumns.length.width }"
-          >
-            <app-sortable-header-field
-              field="length"
-              [label]="allColumns.length.tableLabel"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="arrows"
-              (click)="onSortableHeaderClick(sectorIndex, 'length')"
-            ></app-sortable-header-field>
-          </th>
+            <th
+              class="length"
+              *ngIf="!sector.bouldersOnly && shownColumns.includes('length')"
+              [ngStyle]="{ 'width.px': allColumns.length.width }"
+            >
+              <app-sortable-header-field
+                field="length"
+                [label]="allColumns.length.tableLabel"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="arrows"
+                (click)="onSortableHeaderClick(sectorIndex, 'length')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="grade"
-            *ngIf="shownColumns.includes('difficulty')"
-            [ngStyle]="{ 'width.px': allColumns.difficulty.width }"
-          >
-            <app-sortable-header-field
-              field="difficulty"
-              [label]="allColumns.difficulty.tableLabel"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="arrows"
-              (click)="onSortableHeaderClick(sectorIndex, 'difficulty')"
-            ></app-sortable-header-field>
-          </th>
+            <th
+              class="grade"
+              *ngIf="shownColumns.includes('difficulty')"
+              [ngStyle]="{ 'width.px': allColumns.difficulty.width }"
+            >
+              <app-sortable-header-field
+                field="difficulty"
+                [label]="allColumns.difficulty.tableLabel"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="arrows"
+                (click)="onSortableHeaderClick(sectorIndex, 'difficulty')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="nr-ticks"
-            *ngIf="shownColumns.includes('nrTicks')"
-            [ngStyle]="{ 'width.px': allColumns.nrTicks.width }"
-          >
-            <app-sortable-header-field
-              field="nrTicks"
-              [label]="allColumns.nrTicks.tableLabel"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="arrows"
-              (click)="onSortableHeaderClick(sectorIndex, 'nrTicks')"
-            ></app-sortable-header-field>
-          </th>
+            <th
+              class="nr-ticks"
+              *ngIf="shownColumns.includes('nrTicks')"
+              [ngStyle]="{ 'width.px': allColumns.nrTicks.width }"
+            >
+              <app-sortable-header-field
+                field="nrTicks"
+                [label]="allColumns.nrTicks.tableLabel"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="arrows"
+                (click)="onSortableHeaderClick(sectorIndex, 'nrTicks')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="nr-tries"
-            *ngIf="shownColumns.includes('nrTries')"
-            [ngStyle]="{ 'width.px': allColumns.nrTries.width }"
-          >
-            <app-sortable-header-field
-              field="nrTries"
-              [label]="allColumns.nrTries.tableLabel"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="arrows"
-              (click)="onSortableHeaderClick(sectorIndex, 'nrTries')"
-            ></app-sortable-header-field>
-          </th>
+            <th
+              class="nr-tries"
+              *ngIf="shownColumns.includes('nrTries')"
+              [ngStyle]="{ 'width.px': allColumns.nrTries.width }"
+            >
+              <app-sortable-header-field
+                field="nrTries"
+                [label]="allColumns.nrTries.tableLabel"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="arrows"
+                (click)="onSortableHeaderClick(sectorIndex, 'nrTries')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="nr-climbers"
-            *ngIf="shownColumns.includes('nrClimbers')"
-            [ngStyle]="{ 'width.px': allColumns.nrClimbers.width }"
-          >
-            <app-sortable-header-field
-              field="nrClimbers"
-              [label]="allColumns.nrClimbers.tableLabel"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="arrows"
-              (click)="onSortableHeaderClick(sectorIndex, 'nrClimbers')"
-            ></app-sortable-header-field>
-          </th>
+            <th
+              class="nr-climbers"
+              *ngIf="shownColumns.includes('nrClimbers')"
+              [ngStyle]="{ 'width.px': allColumns.nrClimbers.width }"
+            >
+              <app-sortable-header-field
+                field="nrClimbers"
+                [label]="allColumns.nrClimbers.tableLabel"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="arrows"
+                (click)="onSortableHeaderClick(sectorIndex, 'nrClimbers')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="icon"
-            *ngIf="shownColumns.includes('starRating')"
-            [ngStyle]="{
-              'width.px': allColumns.starRating.width,
-              'min-width.px': allColumns.starRating.width
-            }"
-          >
-            <app-sortable-header-field
-              field="starRating"
-              icon="star"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="highlight"
-              [centered]="true"
-              (click)="onSortableHeaderClick(sectorIndex, 'starRating')"
-            ></app-sortable-header-field>
-          </th>
+            <th
+              class="icon"
+              *ngIf="shownColumns.includes('starRating')"
+              [ngStyle]="{
+                'width.px': allColumns.starRating.width,
+                'min-width.px': allColumns.starRating.width
+              }"
+            >
+              <app-sortable-header-field
+                field="starRating"
+                icon="star"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="highlight"
+                [centered]="true"
+                (click)="onSortableHeaderClick(sectorIndex, 'starRating')"
+              ></app-sortable-header-field>
+            </th>
 
-          <th
-            class="icon"
-            *ngIf="shownColumns.includes('multipitch')"
-            [ngStyle]="{
-              'width.px': allColumns.multipitch.width,
-              'min-width.px': allColumns.multipitch.width
-            }"
-          >
-            <app-sortable-header-field
-              field="multipitch"
-              svgIcon="multipitch"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="highlight"
-              [centered]="true"
-              (click)="onSortableHeaderClick(sectorIndex, 'multipitch')"
-            ></app-sortable-header-field>
-          </th>
-
-          <th
-            class="icon"
-            *ngIf="shownColumns.includes('comments')"
-            [ngStyle]="{
-              'width.px': allColumns.comments.width,
-              'min-width.px': allColumns.comments.width
-            }"
-          >
-            <app-sortable-header-field
-              field="comments"
-              icon="comment"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="highlight"
-              [centered]="true"
-              (click)="onSortableHeaderClick(sectorIndex, 'comments')"
-            ></app-sortable-header-field>
-          </th>
-
-          <th
-            class="icon"
-            *ngIf="shownColumns.includes('myAscents')"
-            [ngStyle]="{
-              'width.px': allColumns.myAscents.width,
-              'min-width.px': allColumns.myAscents.width
-            }"
-          >
-            <app-sortable-header-field
-              field="myAscents"
-              icon="check"
-              [currentlySortedField]="sector.sortedField"
-              [currentSortDirection]="sector.sortedDirection"
-              sortIndication="highlight"
-              [centered]="true"
-              (click)="onSortableHeaderClick(sectorIndex, 'myAscents')"
-            ></app-sortable-header-field>
-          </th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <ng-container *ngFor="let route of sector.routes">
-          <tr
-            (click)="expandRow(route.id)"
-            [ngClass]="{ selected: route.id === expandedRowId }"
-          >
-            <td class="checkbox">
-              <div class="route-checkbox">
-                <mat-checkbox
-                  (change)="changeSelection(route)"
-                  (click)="onCheckBoxClick($event)"
-                  [checked]="selectedRoutesIds.indexOf(route.id) > -1"
-                >
-                </mat-checkbox>
-              </div>
-            </td>
-
-            <td class="name" *ngIf="shownColumns.includes('name')">
-              <a
-                [routerLink]="
-                  section === 'alpinism'
-                    ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
-                    : ['/plezalisce', crag.slug, 'smer', route.slug]
-                "
-                (click)="$event.stopPropagation()"
-                >{{ route.name }}</a
-              >
-            </td>
-
-            <td *ngIf="!sector.bouldersOnly && shownColumns.includes('length')">
-              <ng-container
-                *ngIf="route.routeType.id !== 'boulder' && route.length"
-                >{{ route.length }} m</ng-container
-              >
-            </td>
-
-            <td *ngIf="shownColumns.includes('difficulty')">
-              <span *ngIf="route.isProject">P</span>
-              <app-grade
-                *ngIf="!route.isProject"
-                [difficulty]="route.difficulty"
-                [showModifier]="true"
-                [gradingSystemId]="route.defaultGradingSystem.id"
-              ></app-grade>
-            </td>
-
-            <td *ngIf="shownColumns.includes('nrTicks')">
-              {{ route.nrTicks }}
-            </td>
-
-            <td *ngIf="shownColumns.includes('nrTries')">
-              {{ route.nrTries }}
-            </td>
-
-            <td *ngIf="shownColumns.includes('nrClimbers')">
-              {{ route.nrClimbers }}
-            </td>
-
-            <td *ngIf="shownColumns.includes('starRating')" class="icon">
-              <mat-icon *ngIf="math.round(route.starRating) == 1" title="Lepa">
-                star_border
-              </mat-icon>
-              <mat-icon
-                *ngIf="math.round(route.starRating) == 2"
-                title="Čudovita"
-              >
-                star
-              </mat-icon>
-            </td>
-
-            <td *ngIf="shownColumns.includes('multipitch')" class="icon">
-              <mat-icon
-                *ngIf="route.pitches.length > 0"
+            <th
+              class="icon"
+              *ngIf="shownColumns.includes('multipitch')"
+              [ngStyle]="{
+                'width.px': allColumns.multipitch.width,
+                'min-width.px': allColumns.multipitch.width
+              }"
+            >
+              <app-sortable-header-field
+                field="multipitch"
                 svgIcon="multipitch"
-                title="Večraztežajna"
-              ></mat-icon>
-            </td>
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="highlight"
+                [centered]="true"
+                (click)="onSortableHeaderClick(sectorIndex, 'multipitch')"
+              ></app-sortable-header-field>
+            </th>
 
-            <td *ngIf="shownColumns.includes('comments')" class="icon">
-              <mat-icon *ngIf="route.comments.length > 0" title="Ima komentarje"
-                >comment</mat-icon
-              >
-            </td>
+            <th
+              class="icon"
+              *ngIf="shownColumns.includes('comments')"
+              [ngStyle]="{
+                'width.px': allColumns.comments.width,
+                'min-width.px': allColumns.comments.width
+              }"
+            >
+              <app-sortable-header-field
+                field="comments"
+                icon="comment"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="highlight"
+                [centered]="true"
+                (click)="onSortableHeaderClick(sectorIndex, 'comments')"
+              ></app-sortable-header-field>
+            </th>
 
-            <td *ngIf="shownColumns.includes('myAscents')" class="icon">
-              <app-ascent-type
-                *ngIf="ascents[route.id] != null"
-                [value]="ascents[route.id]"
-                displayType="icon"
-              >
-              </app-ascent-type>
-            </td>
+            <th
+              class="icon"
+              *ngIf="shownColumns.includes('myAscents')"
+              [ngStyle]="{
+                'width.px': allColumns.myAscents.width,
+                'min-width.px': allColumns.myAscents.width
+              }"
+            >
+              <app-sortable-header-field
+                field="myAscents"
+                icon="check"
+                [currentlySortedField]="sector.sortedField"
+                [currentSortDirection]="sector.sortedDirection"
+                sortIndication="highlight"
+                [centered]="true"
+                (click)="onSortableHeaderClick(sectorIndex, 'myAscents')"
+              ></app-sortable-header-field>
+            </th>
           </tr>
+        </thead>
 
-          <tr class="details-row selected">
-            <td [attr.colspan]="shownColumns.length + 1">
-              <div
-                class="route-expanding-container"
-                [ngStyle]="{
-                  'max-height.px':
-                    route.id === expandedRowId ? expandedRowHeight : 0
-                }"
+        <tbody>
+          <ng-container *ngFor="let route of sector.routes">
+            <ng-container *ngIf="route.show">
+              <tr
+                (click)="expandRow(route.id)"
+                [ngClass]="{ selected: route.id === expandedRowId }"
               >
-                <div
+                <td class="checkbox">
+                  <div class="route-checkbox">
+                    <mat-checkbox
+                      (change)="changeSelection(route)"
+                      (click)="onCheckBoxClick($event)"
+                      [checked]="selectedRoutesIds.indexOf(route.id) > -1"
+                    >
+                    </mat-checkbox>
+                  </div>
+                </td>
+
+                <td class="name" *ngIf="shownColumns.includes('name')">
+                  <a
+                    [routerLink]="
+                      section === 'alpinism'
+                        ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
+                        : ['/plezalisce', crag.slug, 'smer', route.slug]
+                    "
+                    (click)="$event.stopPropagation()"
+                    >{{ route.name }}</a
+                  >
+                </td>
+
+                <td
                   *ngIf="
-                    expandedRowId === route.id ||
-                    previousExpandedRowId === route.id
+                    !sector.bouldersOnly && shownColumns.includes('length')
                   "
-                  class="route-expanding-details"
                 >
-                  <app-crag-route-preview
-                    [routeId]="route.id"
-                    (heightChangeEvent)="onPreviewHeightEvent($event)"
-                  ></app-crag-route-preview>
-                </div>
-              </div>
-            </td>
-          </tr>
-        </ng-container>
-      </tbody>
-    </table>
+                  <ng-container
+                    *ngIf="route.routeType.id !== 'boulder' && route.length"
+                    >{{ route.length }} m</ng-container
+                  >
+                </td>
 
-    <!-- Compact view -->
-    <div *ngIf="availableWidth < tableWidth" class="compact shadow mt-16">
-      <ng-container *ngFor="let route of sector.routes">
-        <div
-          (click)="expandRow(route.id)"
-          class="route"
-          [ngClass]="{ selected: route.id === expandedRowId }"
-        >
-          <div class="checkbox">
-            <mat-checkbox
-              (change)="changeSelection(route)"
-              (click)="onCheckBoxClick($event)"
-              [checked]="selectedRoutesIds.indexOf(route.id) > -1"
-            >
-            </mat-checkbox>
-          </div>
-          <div class="info-wrap">
-            <div class="info-row-first">
-              <div *ngIf="shownColumns.includes('name')" class="name">
-                <a
-                  [routerLink]="
-                    section === 'alpinism'
-                      ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
-                      : ['/plezalisce', crag.slug, 'smer', route.slug]
-                  "
-                  (click)="$event.stopPropagation()"
-                  >{{ route.name }}</a
-                >
-              </div>
-
-              <div *ngIf="shownColumns.includes('starRating')" class="star">
-                <mat-icon
-                  *ngIf="math.round(route.starRating) == 1"
-                  title="Lepa"
-                >
-                  star_border
-                </mat-icon>
-                <mat-icon
-                  *ngIf="math.round(route.starRating) == 2"
-                  title="Čudovita"
-                >
-                  star
-                </mat-icon>
-              </div>
-            </div>
-            <div
-              *ngIf="
-                shownColumns.includes('difficulty') ||
-                shownColumns.includes('length') ||
-                shownColumns.includes('multipitch') ||
-                shownColumns.includes('comments') ||
-                shownColumns.includes('myAscents')
-              "
-              class="info-row-second"
-            >
-              <div class="grade-length-wrap">
-                <div *ngIf="shownColumns.includes('difficulty')" class="grade">
-                  <!-- 77 -->
+                <td *ngIf="shownColumns.includes('difficulty')">
                   <span *ngIf="route.isProject">P</span>
                   <app-grade
                     *ngIf="!route.isProject"
@@ -440,95 +305,261 @@
                     [showModifier]="true"
                     [gradingSystemId]="route.defaultGradingSystem.id"
                   ></app-grade>
-                </div>
+                </td>
 
-                <div class="length">
-                  <ng-container
-                    *ngIf="
-                      route.routeType.id !== 'boulder' &&
-                      route.length &&
-                      shownColumns.includes('length')
-                    "
-                    >{{ route.length }} m</ng-container
-                  >
-                </div>
-              </div>
+                <td *ngIf="shownColumns.includes('nrTicks')">
+                  {{ route.nrTicks }}
+                </td>
 
-              <div class="multipitch-comments-my-ascents-wrap">
-                <div
-                  *ngIf="shownColumns.includes('multipitch')"
-                  class="multipitch"
-                >
+                <td *ngIf="shownColumns.includes('nrTries')">
+                  {{ route.nrTries }}
+                </td>
+
+                <td *ngIf="shownColumns.includes('nrClimbers')">
+                  {{ route.nrClimbers }}
+                </td>
+
+                <td *ngIf="shownColumns.includes('starRating')" class="icon">
                   <mat-icon
-                    svgIcon="multipitch"
+                    *ngIf="math.round(route.starRating) == 1"
+                    title="Lepa"
+                  >
+                    star_border
+                  </mat-icon>
+                  <mat-icon
+                    *ngIf="math.round(route.starRating) == 2"
+                    title="Čudovita"
+                  >
+                    star
+                  </mat-icon>
+                </td>
+
+                <td *ngIf="shownColumns.includes('multipitch')" class="icon">
+                  <mat-icon
                     *ngIf="route.pitches.length > 0"
+                    svgIcon="multipitch"
                     title="Večraztežajna"
                   ></mat-icon>
-                </div>
-                <div *ngIf="shownColumns.includes('comments')" class="comments">
+                </td>
+
+                <td *ngIf="shownColumns.includes('comments')" class="icon">
                   <mat-icon
                     *ngIf="route.comments.length > 0"
                     title="Ima komentarje"
                     >comment</mat-icon
                   >
-                </div>
-                <div
-                  *ngIf="shownColumns.includes('myAscents')"
-                  class="my-ascents"
-                >
+                </td>
+
+                <td *ngIf="shownColumns.includes('myAscents')" class="icon">
                   <app-ascent-type
                     *ngIf="ascents[route.id] != null"
                     [value]="ascents[route.id]"
                     displayType="icon"
                   >
                   </app-ascent-type>
+                </td>
+              </tr>
+
+              <tr class="details-row selected">
+                <td [attr.colspan]="shownColumns.length + 1">
+                  <div
+                    class="route-expanding-container"
+                    [ngStyle]="{
+                      'max-height.px':
+                        route.id === expandedRowId ? expandedRowHeight : 0
+                    }"
+                  >
+                    <div
+                      *ngIf="
+                        expandedRowId === route.id ||
+                        previousExpandedRowId === route.id
+                      "
+                      class="route-expanding-details"
+                    >
+                      <app-crag-route-preview
+                        [routeId]="route.id"
+                        (heightChangeEvent)="onPreviewHeightEvent($event)"
+                      ></app-crag-route-preview>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </ng-container>
+          </ng-container>
+        </tbody>
+      </table>
+
+      <!-- Compact view -->
+      <div *ngIf="availableWidth < tableWidth" class="compact shadow mt-16">
+        <ng-container *ngFor="let route of sector.routes">
+          <ng-container *ngIf="route.show">
+            <div
+              (click)="expandRow(route.id)"
+              class="route"
+              [ngClass]="{ selected: route.id === expandedRowId }"
+            >
+              <div class="checkbox">
+                <mat-checkbox
+                  (change)="changeSelection(route)"
+                  (click)="onCheckBoxClick($event)"
+                  [checked]="selectedRoutesIds.indexOf(route.id) > -1"
+                >
+                </mat-checkbox>
+              </div>
+              <div class="info-wrap">
+                <div class="info-row-first">
+                  <div *ngIf="shownColumns.includes('name')" class="name">
+                    <a
+                      [routerLink]="
+                        section === 'alpinism'
+                          ? [
+                              '/alpinizem',
+                              'stena',
+                              crag.slug,
+                              'smer',
+                              route.slug
+                            ]
+                          : ['/plezalisce', crag.slug, 'smer', route.slug]
+                      "
+                      (click)="$event.stopPropagation()"
+                      >{{ route.name }}</a
+                    >
+                  </div>
+
+                  <div *ngIf="shownColumns.includes('starRating')" class="star">
+                    <mat-icon
+                      *ngIf="math.round(route.starRating) == 1"
+                      title="Lepa"
+                    >
+                      star_border
+                    </mat-icon>
+                    <mat-icon
+                      *ngIf="math.round(route.starRating) == 2"
+                      title="Čudovita"
+                    >
+                      star
+                    </mat-icon>
+                  </div>
+                </div>
+                <div
+                  *ngIf="
+                    shownColumns.includes('difficulty') ||
+                    shownColumns.includes('length') ||
+                    shownColumns.includes('multipitch') ||
+                    shownColumns.includes('comments') ||
+                    shownColumns.includes('myAscents')
+                  "
+                  class="info-row-second"
+                >
+                  <div class="grade-length-wrap">
+                    <div
+                      *ngIf="shownColumns.includes('difficulty')"
+                      class="grade"
+                    >
+                      <!-- 77 -->
+                      <span *ngIf="route.isProject">P</span>
+                      <app-grade
+                        *ngIf="!route.isProject"
+                        [difficulty]="route.difficulty"
+                        [showModifier]="true"
+                        [gradingSystemId]="route.defaultGradingSystem.id"
+                      ></app-grade>
+                    </div>
+
+                    <div class="length">
+                      <ng-container
+                        *ngIf="
+                          route.routeType.id !== 'boulder' &&
+                          route.length &&
+                          shownColumns.includes('length')
+                        "
+                        >{{ route.length }} m</ng-container
+                      >
+                    </div>
+                  </div>
+
+                  <div class="multipitch-comments-my-ascents-wrap">
+                    <div
+                      *ngIf="shownColumns.includes('multipitch')"
+                      class="multipitch"
+                    >
+                      <mat-icon
+                        svgIcon="multipitch"
+                        *ngIf="route.pitches.length > 0"
+                        title="Večraztežajna"
+                      ></mat-icon>
+                    </div>
+                    <div
+                      *ngIf="shownColumns.includes('comments')"
+                      class="comments"
+                    >
+                      <mat-icon
+                        *ngIf="route.comments.length > 0"
+                        title="Ima komentarje"
+                        >comment</mat-icon
+                      >
+                    </div>
+                    <div
+                      *ngIf="shownColumns.includes('myAscents')"
+                      class="my-ascents"
+                    >
+                      <app-ascent-type
+                        *ngIf="ascents[route.id] != null"
+                        [value]="ascents[route.id]"
+                        displayType="icon"
+                      >
+                      </app-ascent-type>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="info-row-third">
+                  <span *ngIf="shownColumns.includes('nrTicks')"
+                    >{{ route.nrTicks | pluralizeNoun: "uspešen vzpon"
+                    }}<ng-container
+                      *ngIf="
+                        shownColumns.includes('nrTries') ||
+                        shownColumns.includes('nrClimbers')
+                      "
+                      >,
+                    </ng-container></span
+                  >
+                  <span *ngIf="shownColumns.includes('nrTries')"
+                    >{{ route.nrTries | pluralizeNoun: "poskus"
+                    }}<ng-container *ngIf="shownColumns.includes('nrClimbers')"
+                      >,
+                    </ng-container></span
+                  >
+                  <span *ngIf="shownColumns.includes('nrClimbers')">{{
+                    route.nrClimbers | pluralizeNoun: "plezalec"
+                  }}</span>
                 </div>
               </div>
             </div>
 
-            <div class="info-row-third">
-              <span *ngIf="shownColumns.includes('nrTicks')"
-                >{{ route.nrTicks | pluralizeNoun: "uspešen vzpon"
-                }}<ng-container
-                  *ngIf="
-                    shownColumns.includes('nrTries') ||
-                    shownColumns.includes('nrClimbers')
-                  "
-                  >,
-                </ng-container></span
+            <div
+              class="route-expanding-container selected"
+              [ngStyle]="{
+                'max-height.px':
+                  route.id === expandedRowId ? expandedRowHeight : 0
+              }"
+            >
+              <div
+                *ngIf="
+                  expandedRowId === route.id ||
+                  previousExpandedRowId === route.id
+                "
+                class="route-expanding-details"
               >
-              <span *ngIf="shownColumns.includes('nrTries')"
-                >{{ route.nrTries | pluralizeNoun: "poskus"
-                }}<ng-container *ngIf="shownColumns.includes('nrClimbers')"
-                  >,
-                </ng-container></span
-              >
-              <span *ngIf="shownColumns.includes('nrClimbers')">{{
-                route.nrClimbers | pluralizeNoun: "plezalec"
-              }}</span>
+                <app-crag-route-preview
+                  [routeId]="route.id"
+                  (heightChangeEvent)="onPreviewHeightEvent($event)"
+                ></app-crag-route-preview>
+              </div>
             </div>
-          </div>
-        </div>
-
-        <div
-          class="route-expanding-container selected"
-          [ngStyle]="{
-            'max-height.px': route.id === expandedRowId ? expandedRowHeight : 0
-          }"
-        >
-          <div
-            *ngIf="
-              expandedRowId === route.id || previousExpandedRowId === route.id
-            "
-            class="route-expanding-details"
-          >
-            <app-crag-route-preview
-              [routeId]="route.id"
-              (heightChangeEvent)="onPreviewHeightEvent($event)"
-            ></app-crag-route-preview>
-          </div>
-        </div>
-      </ng-container>
-    </div>
+          </ng-container>
+        </ng-container>
+      </div>
+    </ng-container>
   </div>
 </ng-container>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -1,59 +1,232 @@
 <ng-container *ngIf="!loading">
-  <div *ngFor="let sector of crag.sectors">
-    <h3>
+  <div>
+    <mat-form-field class="mt-16 no-hint">
+      <mat-label>Prikazani stolpci</mat-label>
+      <mat-select [(value)]="shownColumns" multiple>
+        <mat-select-trigger>
+          <span *ngFor="let shownColumn of shownColumns; let last = last"
+            >{{ allColumns[shownColumn].selectLabel
+            }}<span *ngIf="!last">, </span>
+          </span>
+        </mat-select-trigger>
+        <mat-option
+          *ngFor="let column of allColumns | keyvalue: originalOrder"
+          [value]="column.value.field"
+          ><span *ngIf="column.value.field === 'starRating'"
+            ><mat-icon>star</mat-icon>{{ column.value.selectLabel }}</span
+          ><span *ngIf="column.value.field === 'multipitch'"
+            ><mat-icon svgIcon="multipitch"></mat-icon
+            >{{ column.value.selectLabel }}</span
+          ><span *ngIf="column.value.field === 'comments'"
+            ><mat-icon>comment</mat-icon>{{ column.value.selectLabel }}</span
+          ><span *ngIf="column.value.field === 'myAscents'"
+            ><mat-icon>check</mat-icon>{{ column.value.selectLabel }}</span
+          ><span
+            *ngIf="
+              column.value.field !== 'starRating' &&
+              column.value.field !== 'multipitch' &&
+              column.value.field !== 'comments' &&
+              column.value.field !== 'myAscents'
+            "
+            >{{ column.value.selectLabel }}</span
+          ></mat-option
+        >
+      </mat-select>
+    </mat-form-field>
+  </div>
+
+  <div *ngFor="let sector of sectors; let sectorIndex = index">
+    <h3 *ngIf="sector.label || sector.name" class="sector-heading">
       {{ sector.label }}
       <span>{{ sector.name != "" ? " - " + sector.name : "" }}</span>
     </h3>
-    <div class="card">
-      <div class="row header route-row" fxLayoutGap="14px">
-        <div class="route-checkbox"></div>
-        <div class="route-details-container">
-          <div class="route-details left" fxLayoutGap="14px">
-            <div class="route-name">Ime</div>
-            <div *ngIf="!sector.bouldersOnly" class="route-length">Dolžina</div>
-            <div class="route-grade">Težavnost</div>
-          </div>
-          <div class="route-details right" fxLayoutGap="14px">
-            <div class="route-icons"></div>
-          </div>
-        </div>
-      </div>
 
-      <div *ngFor="let route of sector.routes">
-        <div
-          class="row route-row"
-          fxLayoutGap="14px"
-          (click)="expandRow(route.id)"
-        >
-          <div class="route-checkbox">
-            <mat-checkbox
-              (change)="changeSelection(route)"
-              (click)="onCheckBoxClick($event)"
-              [checked]="selectedRoutesIds.indexOf(route.id) > -1"
-            >
-            </mat-checkbox>
-          </div>
-          <div class="route-details-container">
-            <div class="route-details left" fxLayoutGap="14px">
-              <div class="route-name">
-                <a
-                  [routerLink]="
-                    section === 'alpinism'
-                      ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
-                      : ['/plezalisce', crag.slug, 'smer', route.slug]
+    <div class="scroll-shadows-table-wrap mt-16">
+      <div
+        class="left-scroll-shadow"
+        [ngClass]="{ show: sector.showLeftShadow ? true : false }"
+      ></div>
+      <div
+        class="right-scroll-shadow"
+        [ngClass]="{ show: sector.showRightShadow ? true : false }"
+      ></div>
+
+      <div class="table-wrap" id="{{ 'sectorTableWrap' + sector.id }}">
+        <div id="{{ 'leftEdge' + sector.id }}"></div>
+        <table>
+          <thead>
+            <tr>
+              <th class="checkbox">
+                <app-sortable-header-field
+                  field="position"
+                  label="#"
+                  [currentlySortedField]="sector.sortedField"
+                  sortIndication="highlight"
+                  [centered]="true"
+                  (click)="sortRoutes(sectorIndex, 'position')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th class="name" *ngIf="shownColumns.includes('name')">
+                <app-sortable-header-field
+                  field="name"
+                  [label]="allColumns.name.tableLabel"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="arrows"
+                  (click)="sortRoutes(sectorIndex, 'name')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th
+                *ngIf="!sector.bouldersOnly && shownColumns.includes('length')"
+                class="length"
+              >
+                <app-sortable-header-field
+                  field="length"
+                  [label]="allColumns.length.tableLabel"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="arrows"
+                  (click)="sortRoutes(sectorIndex, 'length')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th *ngIf="shownColumns.includes('difficulty')" class="grade">
+                <app-sortable-header-field
+                  field="difficulty"
+                  [label]="allColumns.difficulty.tableLabel"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="arrows"
+                  (click)="sortRoutes(sectorIndex, 'difficulty')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th *ngIf="shownColumns.includes('nrTicks')" class="nr-ticks">
+                <app-sortable-header-field
+                  field="nrTicks"
+                  [label]="allColumns.nrTicks.tableLabel"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="arrows"
+                  (click)="sortRoutes(sectorIndex, 'nrTicks')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th *ngIf="shownColumns.includes('nrTries')" class="nr-tries">
+                <app-sortable-header-field
+                  field="nrTries"
+                  [label]="allColumns.nrTries.tableLabel"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="arrows"
+                  (click)="sortRoutes(sectorIndex, 'nrTries')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th
+                *ngIf="shownColumns.includes('nrClimbers')"
+                class="nr-climbers"
+              >
+                <app-sortable-header-field
+                  field="nrClimbers"
+                  [label]="allColumns.nrClimbers.tableLabel"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="arrows"
+                  (click)="sortRoutes(sectorIndex, 'nrClimbers')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th *ngIf="shownColumns.includes('starRating')" class="icon">
+                <app-sortable-header-field
+                  field="starRating"
+                  icon="star"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="highlight"
+                  [centered]="true"
+                  (click)="sortRoutes(sectorIndex, 'starRating')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th *ngIf="shownColumns.includes('multipitch')" class="icon">
+                <app-sortable-header-field
+                  field="multipitch"
+                  svgIcon="multipitch"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="highlight"
+                  [centered]="true"
+                  (click)="sortRoutes(sectorIndex, 'multipitch')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th *ngIf="shownColumns.includes('comments')" class="icon">
+                <app-sortable-header-field
+                  field="comments"
+                  icon="comment"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="highlight"
+                  [centered]="true"
+                  (click)="sortRoutes(sectorIndex, 'comments')"
+                ></app-sortable-header-field>
+              </th>
+
+              <th *ngIf="shownColumns.includes('myAscents')" class="icon">
+                <app-sortable-header-field
+                  field="myAscents"
+                  icon="check"
+                  [currentlySortedField]="sector.sortedField"
+                  [currentSortDirection]="sector.sortedDirection"
+                  sortIndication="highlight"
+                  [centered]="true"
+                  (click)="sortRoutes(sectorIndex, 'myAscents')"
+                ></app-sortable-header-field>
+              </th>
+            </tr>
+          </thead>
+
+          <tbody>
+            <ng-container *ngFor="let route of sector.routes">
+              <tr (click)="expandRow(route.id)">
+                <td class="checkbox">
+                  <div class="route-checkbox">
+                    <mat-checkbox
+                      (change)="changeSelection(route)"
+                      (click)="onCheckBoxClick($event)"
+                      [checked]="selectedRoutesIds.indexOf(route.id) > -1"
+                    >
+                    </mat-checkbox>
+                  </div>
+                </td>
+
+                <td class="name" *ngIf="shownColumns.includes('name')">
+                  <a
+                    [routerLink]="
+                      section === 'alpinism'
+                        ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
+                        : ['/plezalisce', crag.slug, 'smer', route.slug]
+                    "
+                    (click)="$event.stopPropagation()"
+                    >{{ route.name }}</a
+                  >
+                </td>
+
+                <td
+                  *ngIf="
+                    !sector.bouldersOnly && shownColumns.includes('length')
                   "
-                  (click)="$event.stopPropagation()"
-                  >{{ route.name }}</a
                 >
-              </div>
-              <div class="route-numbers">
-                <div *ngIf="!sector.bouldersOnly" class="route-length">
                   <ng-container
                     *ngIf="route.routeType.id !== 'boulder' && route.length"
                     >{{ route.length }} m</ng-container
                   >
-                </div>
-                <div class="route-grade">
+                </td>
+
+                <td *ngIf="shownColumns.includes('difficulty')">
                   <span *ngIf="route.isProject">P</span>
                   <app-grade
                     *ngIf="!route.isProject"
@@ -61,49 +234,85 @@
                     [showModifier]="true"
                     [gradingSystemId]="route.defaultGradingSystem.id"
                   ></app-grade>
-                </div>
-              </div>
-            </div>
-            <div class="route-details right" fxLayoutGap="14px">
-              <div class="route-icons">
-                <button
-                  *ngIf="route.pitches.length > 0"
-                  mat-icon-button
-                  color="primary"
-                >
-                  MP
-                </button>
-                <button *ngIf="route.comments.length > 0" mat-icon-button>
-                  <mat-icon>comment</mat-icon>
-                </button>
-                <app-ascent-type
-                  *ngIf="ascents[route.id] != null"
-                  [value]="ascents[route.id]"
-                  displayType="icon"
-                >
-                </app-ascent-type>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          class="route-expanding-container"
-          [ngStyle]="{
-            'max-height.px': route.id === expandedRowId ? expandedRowHeight : 0
-          }"
-        >
-          <div
-            *ngIf="
-              expandedRowId === route.id || previousExpandedRowId === route.id
-            "
-            class="route-expanding-details"
-          >
-            <app-crag-route-preview
-              [routeId]="route.id"
-              (heightChangeEvent)="onPreviewHeightEvent($event)"
-            ></app-crag-route-preview>
-          </div>
-        </div>
+                </td>
+
+                <td *ngIf="shownColumns.includes('nrTicks')">
+                  {{ route.nrTicks }}
+                </td>
+
+                <td *ngIf="shownColumns.includes('nrTries')">
+                  {{ route.nrTries }}
+                </td>
+
+                <td *ngIf="shownColumns.includes('nrClimbers')">
+                  {{ route.nrClimbers }}
+                </td>
+
+                <td *ngIf="shownColumns.includes('starRating')" class="icon">
+                  <button
+                    *ngIf="math.round(route.starRating) == 1"
+                    mat-icon-button
+                  >
+                    <mat-icon>star_border</mat-icon>
+                  </button>
+                  <button
+                    *ngIf="math.round(route.starRating) == 2"
+                    mat-icon-button
+                  >
+                    <mat-icon>star</mat-icon>
+                  </button>
+                </td>
+
+                <td *ngIf="shownColumns.includes('multipitch')" class="icon">
+                  <button *ngIf="route.pitches.length > 0" mat-icon-button>
+                    <mat-icon svgIcon="multipitch"></mat-icon>
+                  </button>
+                </td>
+
+                <td *ngIf="shownColumns.includes('comments')" class="icon">
+                  <button *ngIf="route.comments.length > 0" mat-icon-button>
+                    <mat-icon>comment</mat-icon>
+                  </button>
+                </td>
+
+                <td *ngIf="shownColumns.includes('myAscents')" class="icon">
+                  <app-ascent-type
+                    *ngIf="ascents[route.id] != null"
+                    [value]="ascents[route.id]"
+                    displayType="icon"
+                  >
+                  </app-ascent-type>
+                </td>
+              </tr>
+
+              <tr class="details-row">
+                <td [attr.colspan]="shownColumns.length + 1">
+                  <div
+                    class="route-expanding-container"
+                    [ngStyle]="{
+                      'max-height.px':
+                        route.id === expandedRowId ? expandedRowHeight : 0
+                    }"
+                  >
+                    <div
+                      *ngIf="
+                        expandedRowId === route.id ||
+                        previousExpandedRowId === route.id
+                      "
+                      class="route-expanding-details"
+                    >
+                      <app-crag-route-preview
+                        [routeId]="route.id"
+                        (heightChangeEvent)="onPreviewHeightEvent($event)"
+                      ></app-crag-route-preview>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </ng-container>
+          </tbody>
+        </table>
+        <div id="{{ 'rightEdge' + sector.id }}"></div>
       </div>
     </div>
   </div>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -5,7 +5,7 @@
       <mat-select
         [(value)]="shownColumns"
         multiple
-        (selectionChange)="recalculateTableWidth($event)"
+        (selectionChange)="onSelectedColumnsSelectionChange($event)"
       >
         <mat-select-trigger>
           <span *ngFor="let shownColumn of shownColumns; let last = last"

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -1,8 +1,15 @@
 <ng-container *ngIf="!loading">
-  <div>
-    <mat-form-field class="mt-16 no-hint">
-      <mat-label>Prikazani stolpci</mat-label>
-      <mat-select [(value)]="shownColumns" multiple>
+  <div class="select-columns-and-sort-wrap mt-16">
+    <mat-form-field
+      class="no-hint"
+      [ngClass]="{ 'max-half': availableWidth >= tableWidth }"
+    >
+      <mat-label>Prikaži stolpce</mat-label>
+      <mat-select
+        [(value)]="shownColumns"
+        multiple
+        (selectionChange)="recalculateTableWidth($event)"
+      >
         <mat-select-trigger>
           <span *ngFor="let shownColumn of shownColumns; let last = last"
             >{{ allColumns[shownColumn].selectLabel
@@ -12,6 +19,7 @@
         <mat-option
           *ngFor="let column of allColumns | keyvalue: originalOrder"
           [value]="column.value.field"
+          [id]="column.value.field"
           ><span *ngIf="column.value.field === 'starRating'"
             ><mat-icon>star</mat-icon>{{ column.value.selectLabel }}</span
           ><span *ngIf="column.value.field === 'multipitch'"
@@ -33,6 +41,27 @@
         >
       </mat-select>
     </mat-form-field>
+
+    <mat-form-field
+      class="no-hint"
+      [ngClass]="{ hidden: availableWidth >= tableWidth }"
+    >
+      <mat-label>Uredi smeri</mat-label>
+      <mat-select
+        [(ngModel)]="sortAll"
+        (selectionChange)="sortAllRoutes($event)"
+      >
+        <mat-option [value]="['position', 1]">Od leve proti desni</mat-option>
+        <ng-container *ngFor="let column of shownColumns">
+          <mat-option [value]="[column, 1]">{{
+            allColumns[column].selectLabel + ", naraščajoče"
+          }}</mat-option>
+          <mat-option [value]="[column, -1]">{{
+            allColumns[column].selectLabel + ", padajoče"
+          }}</mat-option>
+        </ng-container>
+      </mat-select>
+    </mat-form-field>
   </div>
 
   <div *ngFor="let sector of sectors; let sectorIndex = index">
@@ -41,192 +70,362 @@
       <span>{{ sector.name != "" ? " - " + sector.name : "" }}</span>
     </h3>
 
-    <div class="scroll-shadows-table-wrap mt-16">
-      <div
-        class="left-scroll-shadow"
-        [ngClass]="{ show: sector.showLeftShadow ? true : false }"
-      ></div>
-      <div
-        class="right-scroll-shadow"
-        [ngClass]="{ show: sector.showRightShadow ? true : false }"
-      ></div>
+    <!-- Table view -->
+    <table *ngIf="availableWidth >= tableWidth" class="shadow mt-16">
+      <thead>
+        <tr>
+          <th class="checkbox">
+            <app-sortable-header-field
+              field="position"
+              label="#"
+              [currentlySortedField]="sector.sortedField"
+              sortIndication="highlight"
+              [centered]="true"
+              (click)="onSortableHeaderClick(sectorIndex, 'position')"
+            ></app-sortable-header-field>
+          </th>
 
-      <div class="table-wrap" id="{{ 'sectorTableWrap' + sector.id }}">
-        <div id="{{ 'leftEdge' + sector.id }}"></div>
-        <table>
-          <thead>
-            <tr>
-              <th class="checkbox">
-                <app-sortable-header-field
-                  field="position"
-                  label="#"
-                  [currentlySortedField]="sector.sortedField"
-                  sortIndication="highlight"
-                  [centered]="true"
-                  (click)="sortRoutes(sectorIndex, 'position')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="name"
+            *ngIf="shownColumns.includes('name')"
+            [ngStyle]="{ 'min-width.px': allColumns.name.width }"
+          >
+            <app-sortable-header-field
+              field="name"
+              [label]="allColumns.name.tableLabel"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="arrows"
+              (click)="onSortableHeaderClick(sectorIndex, 'name')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th class="name" *ngIf="shownColumns.includes('name')">
-                <app-sortable-header-field
-                  field="name"
-                  [label]="allColumns.name.tableLabel"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="arrows"
-                  (click)="sortRoutes(sectorIndex, 'name')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="length"
+            *ngIf="!sector.bouldersOnly && shownColumns.includes('length')"
+            [ngStyle]="{ 'width.px': allColumns.length.width }"
+          >
+            <app-sortable-header-field
+              field="length"
+              [label]="allColumns.length.tableLabel"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="arrows"
+              (click)="onSortableHeaderClick(sectorIndex, 'length')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th
-                *ngIf="!sector.bouldersOnly && shownColumns.includes('length')"
-                class="length"
-              >
-                <app-sortable-header-field
-                  field="length"
-                  [label]="allColumns.length.tableLabel"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="arrows"
-                  (click)="sortRoutes(sectorIndex, 'length')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="grade"
+            *ngIf="shownColumns.includes('difficulty')"
+            [ngStyle]="{ 'width.px': allColumns.difficulty.width }"
+          >
+            <app-sortable-header-field
+              field="difficulty"
+              [label]="allColumns.difficulty.tableLabel"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="arrows"
+              (click)="onSortableHeaderClick(sectorIndex, 'difficulty')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th *ngIf="shownColumns.includes('difficulty')" class="grade">
-                <app-sortable-header-field
-                  field="difficulty"
-                  [label]="allColumns.difficulty.tableLabel"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="arrows"
-                  (click)="sortRoutes(sectorIndex, 'difficulty')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="nr-ticks"
+            *ngIf="shownColumns.includes('nrTicks')"
+            [ngStyle]="{ 'width.px': allColumns.nrTicks.width }"
+          >
+            <app-sortable-header-field
+              field="nrTicks"
+              [label]="allColumns.nrTicks.tableLabel"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="arrows"
+              (click)="onSortableHeaderClick(sectorIndex, 'nrTicks')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th *ngIf="shownColumns.includes('nrTicks')" class="nr-ticks">
-                <app-sortable-header-field
-                  field="nrTicks"
-                  [label]="allColumns.nrTicks.tableLabel"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="arrows"
-                  (click)="sortRoutes(sectorIndex, 'nrTicks')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="nr-tries"
+            *ngIf="shownColumns.includes('nrTries')"
+            [ngStyle]="{ 'width.px': allColumns.nrTries.width }"
+          >
+            <app-sortable-header-field
+              field="nrTries"
+              [label]="allColumns.nrTries.tableLabel"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="arrows"
+              (click)="onSortableHeaderClick(sectorIndex, 'nrTries')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th *ngIf="shownColumns.includes('nrTries')" class="nr-tries">
-                <app-sortable-header-field
-                  field="nrTries"
-                  [label]="allColumns.nrTries.tableLabel"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="arrows"
-                  (click)="sortRoutes(sectorIndex, 'nrTries')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="nr-climbers"
+            *ngIf="shownColumns.includes('nrClimbers')"
+            [ngStyle]="{ 'width.px': allColumns.nrClimbers.width }"
+          >
+            <app-sortable-header-field
+              field="nrClimbers"
+              [label]="allColumns.nrClimbers.tableLabel"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="arrows"
+              (click)="onSortableHeaderClick(sectorIndex, 'nrClimbers')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th
-                *ngIf="shownColumns.includes('nrClimbers')"
-                class="nr-climbers"
-              >
-                <app-sortable-header-field
-                  field="nrClimbers"
-                  [label]="allColumns.nrClimbers.tableLabel"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="arrows"
-                  (click)="sortRoutes(sectorIndex, 'nrClimbers')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="icon"
+            *ngIf="shownColumns.includes('starRating')"
+            [ngStyle]="{
+              'width.px': allColumns.starRating.width,
+              'min-width.px': allColumns.starRating.width
+            }"
+          >
+            <app-sortable-header-field
+              field="starRating"
+              icon="star"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="highlight"
+              [centered]="true"
+              (click)="onSortableHeaderClick(sectorIndex, 'starRating')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th *ngIf="shownColumns.includes('starRating')" class="icon">
-                <app-sortable-header-field
-                  field="starRating"
-                  icon="star"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="highlight"
-                  [centered]="true"
-                  (click)="sortRoutes(sectorIndex, 'starRating')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="icon"
+            *ngIf="shownColumns.includes('multipitch')"
+            [ngStyle]="{
+              'width.px': allColumns.multipitch.width,
+              'min-width.px': allColumns.multipitch.width
+            }"
+          >
+            <app-sortable-header-field
+              field="multipitch"
+              svgIcon="multipitch"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="highlight"
+              [centered]="true"
+              (click)="onSortableHeaderClick(sectorIndex, 'multipitch')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th *ngIf="shownColumns.includes('multipitch')" class="icon">
-                <app-sortable-header-field
-                  field="multipitch"
-                  svgIcon="multipitch"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="highlight"
-                  [centered]="true"
-                  (click)="sortRoutes(sectorIndex, 'multipitch')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="icon"
+            *ngIf="shownColumns.includes('comments')"
+            [ngStyle]="{
+              'width.px': allColumns.comments.width,
+              'min-width.px': allColumns.comments.width
+            }"
+          >
+            <app-sortable-header-field
+              field="comments"
+              icon="comment"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="highlight"
+              [centered]="true"
+              (click)="onSortableHeaderClick(sectorIndex, 'comments')"
+            ></app-sortable-header-field>
+          </th>
 
-              <th *ngIf="shownColumns.includes('comments')" class="icon">
-                <app-sortable-header-field
-                  field="comments"
-                  icon="comment"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="highlight"
-                  [centered]="true"
-                  (click)="sortRoutes(sectorIndex, 'comments')"
-                ></app-sortable-header-field>
-              </th>
+          <th
+            class="icon"
+            *ngIf="shownColumns.includes('myAscents')"
+            [ngStyle]="{
+              'width.px': allColumns.myAscents.width,
+              'min-width.px': allColumns.myAscents.width
+            }"
+          >
+            <app-sortable-header-field
+              field="myAscents"
+              icon="check"
+              [currentlySortedField]="sector.sortedField"
+              [currentSortDirection]="sector.sortedDirection"
+              sortIndication="highlight"
+              [centered]="true"
+              (click)="onSortableHeaderClick(sectorIndex, 'myAscents')"
+            ></app-sortable-header-field>
+          </th>
+        </tr>
+      </thead>
 
-              <th *ngIf="shownColumns.includes('myAscents')" class="icon">
-                <app-sortable-header-field
-                  field="myAscents"
-                  icon="check"
-                  [currentlySortedField]="sector.sortedField"
-                  [currentSortDirection]="sector.sortedDirection"
-                  sortIndication="highlight"
-                  [centered]="true"
-                  (click)="sortRoutes(sectorIndex, 'myAscents')"
-                ></app-sortable-header-field>
-              </th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <ng-container *ngFor="let route of sector.routes">
-              <tr (click)="expandRow(route.id)">
-                <td class="checkbox">
-                  <div class="route-checkbox">
-                    <mat-checkbox
-                      (change)="changeSelection(route)"
-                      (click)="onCheckBoxClick($event)"
-                      [checked]="selectedRoutesIds.indexOf(route.id) > -1"
-                    >
-                    </mat-checkbox>
-                  </div>
-                </td>
-
-                <td class="name" *ngIf="shownColumns.includes('name')">
-                  <a
-                    [routerLink]="
-                      section === 'alpinism'
-                        ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
-                        : ['/plezalisce', crag.slug, 'smer', route.slug]
-                    "
-                    (click)="$event.stopPropagation()"
-                    >{{ route.name }}</a
-                  >
-                </td>
-
-                <td
-                  *ngIf="
-                    !sector.bouldersOnly && shownColumns.includes('length')
-                  "
+      <tbody>
+        <ng-container *ngFor="let route of sector.routes">
+          <tr (click)="expandRow(route.id)">
+            <td class="checkbox">
+              <div class="route-checkbox">
+                <mat-checkbox
+                  (change)="changeSelection(route)"
+                  (click)="onCheckBoxClick($event)"
+                  [checked]="selectedRoutesIds.indexOf(route.id) > -1"
                 >
-                  <ng-container
-                    *ngIf="route.routeType.id !== 'boulder' && route.length"
-                    >{{ route.length }} m</ng-container
-                  >
-                </td>
+                </mat-checkbox>
+              </div>
+            </td>
 
-                <td *ngIf="shownColumns.includes('difficulty')">
+            <td class="name" *ngIf="shownColumns.includes('name')">
+              <a
+                [routerLink]="
+                  section === 'alpinism'
+                    ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
+                    : ['/plezalisce', crag.slug, 'smer', route.slug]
+                "
+                (click)="$event.stopPropagation()"
+                >{{ route.name }}</a
+              >
+            </td>
+
+            <td *ngIf="!sector.bouldersOnly && shownColumns.includes('length')">
+              <ng-container
+                *ngIf="route.routeType.id !== 'boulder' && route.length"
+                >{{ route.length }} m</ng-container
+              >
+            </td>
+
+            <td *ngIf="shownColumns.includes('difficulty')">
+              <span *ngIf="route.isProject">P</span>
+              <app-grade
+                *ngIf="!route.isProject"
+                [difficulty]="route.difficulty"
+                [showModifier]="true"
+                [gradingSystemId]="route.defaultGradingSystem.id"
+              ></app-grade>
+            </td>
+
+            <td *ngIf="shownColumns.includes('nrTicks')">
+              {{ route.nrTicks }}
+            </td>
+
+            <td *ngIf="shownColumns.includes('nrTries')">
+              {{ route.nrTries }}
+            </td>
+
+            <td *ngIf="shownColumns.includes('nrClimbers')">
+              {{ route.nrClimbers }}
+            </td>
+
+            <td *ngIf="shownColumns.includes('starRating')" class="icon">
+              <mat-icon *ngIf="math.round(route.starRating) == 1" title="Lepa">
+                star_border
+              </mat-icon>
+              <mat-icon
+                *ngIf="math.round(route.starRating) == 2"
+                title="Čudovita"
+              >
+                star
+              </mat-icon>
+            </td>
+
+            <td *ngIf="shownColumns.includes('multipitch')" class="icon">
+              <mat-icon
+                *ngIf="route.pitches.length > 0"
+                svgIcon="multipitch"
+                title="Večraztežajna"
+              ></mat-icon>
+            </td>
+
+            <td *ngIf="shownColumns.includes('comments')" class="icon">
+              <mat-icon *ngIf="route.comments.length > 0" title="Ima komentarje"
+                >comment</mat-icon
+              >
+            </td>
+
+            <td *ngIf="shownColumns.includes('myAscents')" class="icon">
+              <app-ascent-type
+                *ngIf="ascents[route.id] != null"
+                [value]="ascents[route.id]"
+                displayType="icon"
+              >
+              </app-ascent-type>
+            </td>
+          </tr>
+
+          <tr class="details-row">
+            <td [attr.colspan]="shownColumns.length + 1">
+              <div
+                class="route-expanding-container"
+                [ngStyle]="{
+                  'max-height.px':
+                    route.id === expandedRowId ? expandedRowHeight : 0
+                }"
+              >
+                <div
+                  *ngIf="
+                    expandedRowId === route.id ||
+                    previousExpandedRowId === route.id
+                  "
+                  class="route-expanding-details"
+                >
+                  <app-crag-route-preview
+                    [routeId]="route.id"
+                    (heightChangeEvent)="onPreviewHeightEvent($event)"
+                  ></app-crag-route-preview>
+                </div>
+              </div>
+            </td>
+          </tr>
+        </ng-container>
+      </tbody>
+    </table>
+
+    <!-- Compact view -->
+    <div *ngIf="availableWidth < tableWidth" class="compact shadow mt-16">
+      <ng-container *ngFor="let route of sector.routes">
+        <div (click)="expandRow(route.id)" class="route">
+          <div class="checkbox">
+            <mat-checkbox
+              (change)="changeSelection(route)"
+              (click)="onCheckBoxClick($event)"
+              [checked]="selectedRoutesIds.indexOf(route.id) > -1"
+            >
+            </mat-checkbox>
+          </div>
+          <div class="info-wrap">
+            <div class="info-row-first">
+              <div *ngIf="shownColumns.includes('name')" class="name">
+                <a
+                  [routerLink]="
+                    section === 'alpinism'
+                      ? ['/alpinizem', 'stena', crag.slug, 'smer', route.slug]
+                      : ['/plezalisce', crag.slug, 'smer', route.slug]
+                  "
+                  (click)="$event.stopPropagation()"
+                  >{{ route.name }}</a
+                >
+              </div>
+
+              <div *ngIf="shownColumns.includes('starRating')" class="star">
+                <mat-icon
+                  *ngIf="math.round(route.starRating) == 1"
+                  title="Lepa"
+                >
+                  star_border
+                </mat-icon>
+                <mat-icon
+                  *ngIf="math.round(route.starRating) == 2"
+                  title="Čudovita"
+                >
+                  star
+                </mat-icon>
+              </div>
+            </div>
+            <div
+              *ngIf="
+                shownColumns.includes('difficulty') ||
+                shownColumns.includes('length') ||
+                shownColumns.includes('multipitch') ||
+                shownColumns.includes('comments') ||
+                shownColumns.includes('myAscents')
+              "
+              class="info-row-second"
+            >
+              <div class="grade-length-wrap">
+                <div *ngIf="shownColumns.includes('difficulty')" class="grade">
+                  <!-- 77 -->
                   <span *ngIf="route.isProject">P</span>
                   <app-grade
                     *ngIf="!route.isProject"
@@ -234,86 +433,95 @@
                     [showModifier]="true"
                     [gradingSystemId]="route.defaultGradingSystem.id"
                   ></app-grade>
-                </td>
+                </div>
 
-                <td *ngIf="shownColumns.includes('nrTicks')">
-                  {{ route.nrTicks }}
-                </td>
-
-                <td *ngIf="shownColumns.includes('nrTries')">
-                  {{ route.nrTries }}
-                </td>
-
-                <td *ngIf="shownColumns.includes('nrClimbers')">
-                  {{ route.nrClimbers }}
-                </td>
-
-                <td *ngIf="shownColumns.includes('starRating')" class="icon">
-                  <button
-                    *ngIf="math.round(route.starRating) == 1"
-                    mat-icon-button
+                <div class="length">
+                  <ng-container
+                    *ngIf="
+                      route.routeType.id !== 'boulder' &&
+                      route.length &&
+                      shownColumns.includes('length')
+                    "
+                    >{{ route.length }} m</ng-container
                   >
-                    <mat-icon>star_border</mat-icon>
-                  </button>
-                  <button
-                    *ngIf="math.round(route.starRating) == 2"
-                    mat-icon-button
+                </div>
+              </div>
+
+              <div class="multipitch-comments-my-ascents-wrap">
+                <div
+                  *ngIf="shownColumns.includes('multipitch')"
+                  class="multipitch"
+                >
+                  <mat-icon
+                    svgIcon="multipitch"
+                    *ngIf="route.pitches.length > 0"
+                    title="Večraztežajna"
+                  ></mat-icon>
+                </div>
+                <div *ngIf="shownColumns.includes('comments')" class="comments">
+                  <mat-icon
+                    *ngIf="route.comments.length > 0"
+                    title="Ima komentarje"
+                    >comment</mat-icon
                   >
-                    <mat-icon>star</mat-icon>
-                  </button>
-                </td>
-
-                <td *ngIf="shownColumns.includes('multipitch')" class="icon">
-                  <button *ngIf="route.pitches.length > 0" mat-icon-button>
-                    <mat-icon svgIcon="multipitch"></mat-icon>
-                  </button>
-                </td>
-
-                <td *ngIf="shownColumns.includes('comments')" class="icon">
-                  <button *ngIf="route.comments.length > 0" mat-icon-button>
-                    <mat-icon>comment</mat-icon>
-                  </button>
-                </td>
-
-                <td *ngIf="shownColumns.includes('myAscents')" class="icon">
+                </div>
+                <div
+                  *ngIf="shownColumns.includes('myAscents')"
+                  class="my-ascents"
+                >
                   <app-ascent-type
                     *ngIf="ascents[route.id] != null"
                     [value]="ascents[route.id]"
                     displayType="icon"
                   >
                   </app-ascent-type>
-                </td>
-              </tr>
+                </div>
+              </div>
+            </div>
 
-              <tr class="details-row">
-                <td [attr.colspan]="shownColumns.length + 1">
-                  <div
-                    class="route-expanding-container"
-                    [ngStyle]="{
-                      'max-height.px':
-                        route.id === expandedRowId ? expandedRowHeight : 0
-                    }"
-                  >
-                    <div
-                      *ngIf="
-                        expandedRowId === route.id ||
-                        previousExpandedRowId === route.id
-                      "
-                      class="route-expanding-details"
-                    >
-                      <app-crag-route-preview
-                        [routeId]="route.id"
-                        (heightChangeEvent)="onPreviewHeightEvent($event)"
-                      ></app-crag-route-preview>
-                    </div>
-                  </div>
-                </td>
-              </tr>
-            </ng-container>
-          </tbody>
-        </table>
-        <div id="{{ 'rightEdge' + sector.id }}"></div>
-      </div>
+            <div class="info-row-third">
+              <span *ngIf="shownColumns.includes('nrTicks')"
+                >{{ route.nrTicks | pluralizeNoun: "uspešen vzpon"
+                }}<ng-container
+                  *ngIf="
+                    shownColumns.includes('nrTries') ||
+                    shownColumns.includes('nrClimbers')
+                  "
+                  >,
+                </ng-container></span
+              >
+              <span *ngIf="shownColumns.includes('nrTries')"
+                >{{ route.nrTries | pluralizeNoun: "poskus"
+                }}<ng-container *ngIf="shownColumns.includes('nrClimbers')"
+                  >,
+                </ng-container></span
+              >
+              <span *ngIf="shownColumns.includes('nrClimbers')">{{
+                route.nrClimbers | pluralizeNoun: "plezalec"
+              }}</span>
+            </div>
+          </div>
+        </div>
+
+        <div
+          class="route-expanding-container"
+          [ngStyle]="{
+            'max-height.px': route.id === expandedRowId ? expandedRowHeight : 0
+          }"
+        >
+          <div
+            *ngIf="
+              expandedRowId === route.id || previousExpandedRowId === route.id
+            "
+            class="route-expanding-details"
+          >
+            <app-crag-route-preview
+              [routeId]="route.id"
+              (heightChangeEvent)="onPreviewHeightEvent($event)"
+            ></app-crag-route-preview>
+          </div>
+        </div>
+      </ng-container>
     </div>
   </div>
 </ng-container>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -255,7 +255,10 @@
 
       <tbody>
         <ng-container *ngFor="let route of sector.routes">
-          <tr (click)="expandRow(route.id)">
+          <tr
+            (click)="expandRow(route.id)"
+            [ngClass]="{ selected: route.id === expandedRowId }"
+          >
             <td class="checkbox">
               <div class="route-checkbox">
                 <mat-checkbox
@@ -344,7 +347,7 @@
             </td>
           </tr>
 
-          <tr class="details-row">
+          <tr class="details-row selected">
             <td [attr.colspan]="shownColumns.length + 1">
               <div
                 class="route-expanding-container"
@@ -375,7 +378,11 @@
     <!-- Compact view -->
     <div *ngIf="availableWidth < tableWidth" class="compact shadow mt-16">
       <ng-container *ngFor="let route of sector.routes">
-        <div (click)="expandRow(route.id)" class="route">
+        <div
+          (click)="expandRow(route.id)"
+          class="route"
+          [ngClass]="{ selected: route.id === expandedRowId }"
+        >
           <div class="checkbox">
             <mat-checkbox
               (change)="changeSelection(route)"
@@ -504,7 +511,7 @@
         </div>
 
         <div
-          class="route-expanding-container"
+          class="route-expanding-container selected"
           [ngStyle]="{
             'max-height.px': route.id === expandedRowId ? expandedRowHeight : 0
           }"

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -2,163 +2,346 @@
 @import "../../../../styles/colors.scss";
 @import "../../../../styles/variables.scss";
 
-.route-row {
-  display: flex;
-  flex-direction: row;
-  padding: 6px 2px 6px 16px;
-  min-height: 43px;
+// TODO: define inside variables...
+$gray: #757575;
+$gray-light: #ebebeb;
+$blue-very-light: #f6f9ff;
 
-  &.header {
-    cursor: default;
-    padding-top: 12px;
+mat-form-field {
+  width: 100%;
+}
 
-    @media (max-width: 959px) {
-      display: none;
+// fix options panel overflowing viewport on 100% wide mat-form-field
+::ng-deep .mat-select-panel-wrap {
+  div {
+    min-width: calc(100% + 32px) !important;
+  }
+}
+
+@media (min-width: $breakpoint-sm) {
+  mat-form-field {
+    width: unset;
+  }
+
+  ::ng-deep .mat-select-panel-wrap {
+    div {
+      min-width: unset;
     }
   }
+}
 
-  .mat-checkbox {
-    margin-top: -2px;
+.mat-option {
+  .mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
   }
 }
 
-.route-details-container {
-  flex: 1 1 100%;
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
-  text-align: left;
+.sector-heading {
+  padding: 0;
+  margin-top: 24px;
+  margin-left: 16px;
 }
 
-.route-details {
-  display: flex;
-  flex-direction: row;
-  justify-content: flex-start;
-  align-items: center;
-
-  &.left {
-    flex: 1 1 100%;
-
-    @media (max-width: $breakpoint-sm) {
-      // TODO use min-width instead
-      display: flex;
-      flex-direction: column;
-      align-items: flex-start;
-      justify-content: flex-start;
-    }
-  }
-
-  &.right {
-    flex: 0 0 110px;
-  }
-}
-
-.route-checkbox {
-  flex: 0 0 12px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.route-name {
-  flex: 1 1 100%;
-}
-
-.route-numbers {
-  // TODO take care of boulder places ... different width probably
-  display: flex;
-  flex: 0 0 160px;
-
-  @media (max-width: $breakpoint-sm) {
-    // TODO use min-width instead
-    flex-direction: row;
-    flex: 1 1 auto;
-  }
-}
-
-.route-length {
-  flex: 0 0 80px;
-  height: 20px;
-}
-
-.route-grade {
-  flex: 0 0 80px;
+.scroll-shadows-table-wrap {
   position: relative;
 }
 
-.route-pitches {
-  flex: 0 0 80px;
+.left-scroll-shadow,
+.right-scroll-shadow {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background-color: black;
+  opacity: 0.1;
+  width: 0px;
+  transition: width 300ms;
+
+  &.show {
+    width: 10px;
+  }
+}
+.left-scroll-shadow {
+  left: 0;
+}
+.right-scroll-shadow {
+  right: 0;
 }
 
-.route-icons {
-  flex: 0 0 110px;
+.table-wrap {
+  overflow-x: auto;
+  max-width: 100%;
+  flex-grow: 1;
+  background-color: white;
   display: flex;
-  flex-direction: row;
-  justify-content: flex-end;
-  align-items: center;
-  white-space: nowrap;
-  text-align: right;
-  margin: -4px 0;
+}
 
-  .mat-button {
-    color: #0000008a;
+table {
+  width: 100%;
+
+  tr {
+    height: 53px;
   }
 
-  .mat-icon-button {
-    color: #0000008a;
-    height: 37px;
-    width: 37px;
+  tbody tr {
+    border-top: 1px solid $gray-light;
+    &:hover:not(.details-row) {
+      background-color: $blue-very-light;
+    }
   }
-}
 
-h3 {
-  padding-top: 28px;
-}
+  td,
+  th {
+    padding: 8px;
+    text-align: left;
+    font-weight: normal;
 
-.ascent-type-filler {
-  width: 36px;
-  display: inline-block;
-}
+    &.checkbox {
+      padding-left: 12px;
+      padding-right: 12px;
+      text-align: center;
+      span {
+        cursor: pointer;
+      }
+      mat-checkbox {
+        vertical-align: middle;
+        margin-top: -4px;
+      }
+    }
+    &.name {
+      padding-left: 0;
+    }
+    &.icon {
+      padding-left: 0;
+      padding-right: 0;
+      text-align: center;
+    }
+  }
 
-.difficulty-vote-included {
-  font-weight: bold;
-}
+  th {
+    color: $gray;
+    vertical-align: bottom;
+    white-space: nowrap;
 
-.difficulty-vote-author {
-  padding-right: 20px;
-}
+    &.checkbox {
+      width: 40px;
+      min-width: 40px;
+    }
 
-.grade {
-  width: 50px;
-  display: block;
-}
+    &.name {
+      min-width: 200px;
+    }
+    &.icon {
+      width: 40px;
+      min-width: 40px;
+    }
 
-.difficulty-vote-date {
-  text-align: right;
-}
+    &.length {
+      width: 85px;
+    }
+    &.grade {
+      width: 103px;
+    }
+    &.nr-ticks {
+      width: 118px;
+    }
+    &.nr-tries {
+      width: 100px;
+    }
+    &.nr-climbers {
+      width: 99px;
+    }
+  }
 
-.route-comment:not(.first) {
-  margin-top: 4px;
-  padding-top: 10px;
-}
+  td {
+    vertical-align: middle;
+    &.icon {
+      padding: 0;
+    }
+  }
 
-.route-comment-content {
-  white-space: normal;
-}
-
-.route-comment-author {
-  margin-top: 5px;
-  text-align: right;
-  color: $text-gray;
+  tbody tr.details-row {
+    height: 0;
+    border: none;
+    td {
+      height: 0;
+      padding: 0;
+    }
+  }
 }
 
 .route-expanding-container {
   max-height: 0;
-  transition: max-height 300ms ease-in-out;
+  transition: max-height 225ms cubic-bezier(0.4, 0, 0.2, 1);
   overflow: hidden;
 }
 
 .route-expanding-details {
   padding: 0 20px 20px 20px;
 }
+
+///
+// Keep old styles as a reference until mobile/narrow view is solved
+
+// .route-row {
+//   display: flex;
+//   flex-direction: row;
+//   padding: 6px 2px 6px 16px;
+//   min-height: 43px;
+
+//   &.header {
+//     cursor: default;
+//     padding-top: 12px;
+
+//     @media (max-width: 959px) {
+//       display: none;
+//     }
+//   }
+
+//   .mat-checkbox {
+//     margin-top: -2px;
+//   }
+// }
+
+// .route-details-container {
+//   flex: 1 1 100%;
+//   display: flex;
+//   flex-direction: row;
+//   justify-content: flex-start;
+//   align-items: center;
+//   text-align: left;
+// }
+
+// .route-details {
+//   display: flex;
+//   flex-direction: row;
+//   justify-content: flex-start;
+//   align-items: center;
+
+//   &.left {
+//     flex: 1 1 100%;
+
+//     @media (max-width: $breakpoint-sm) {
+//       // TODO use min-width instead
+//       display: flex;
+//       flex-direction: column;
+//       align-items: flex-start;
+//       justify-content: flex-start;
+//     }
+//   }
+
+//   &.right {
+//     flex: 0 0 110px;
+//   }
+// }
+
+// .route-checkbox {
+//   flex: 0 0 12px;
+//   display: flex;
+//   align-items: center;
+//   justify-content: center;
+// }
+
+// .route-name {
+//   flex: 1 1 100%;
+// }
+
+// .route-numbers {
+//   // TODO take care of boulder places ... different width probably
+//   display: flex;
+//   flex: 0 0 200px;
+
+//   @media (max-width: $breakpoint-sm) {
+//     // TODO use min-width instead
+//     flex-direction: row;
+//     flex: 1 1 auto;
+//   }
+// }
+
+// .route-length {
+//   flex: 0 0 80px;
+//   height: 20px;
+// }
+
+// .route-grade {
+//   flex: 0 0 120px;
+//   position: relative;
+// }
+
+// .route-pitches {
+//   flex: 0 0 80px;
+// }
+
+// .route-icons {
+//   flex: 0 0 110px;
+//   display: flex;
+//   flex-direction: row;
+//   justify-content: flex-end;
+//   align-items: center;
+//   white-space: nowrap;
+//   text-align: right;
+//   margin: -4px 0;
+
+//   .mat-button {
+//     color: #0000008a;
+//   }
+
+//   .mat-icon-button {
+//     color: #0000008a;
+//     height: 37px;
+//     width: 37px;
+//   }
+// }
+
+// h3 {
+//   padding-top: 28px;
+// }
+
+// .ascent-type-filler {
+//   width: 36px;
+//   display: inline-block;
+// }
+
+// .difficulty-vote-included {
+//   font-weight: bold;
+// }
+
+// .difficulty-vote-author {
+//   padding-right: 20px;
+// }
+
+// .grade {
+//   width: 50px;
+//   display: block;
+// }
+
+// .difficulty-vote-date {
+//   text-align: right;
+// }
+
+// .route-comment:not(.first) {
+//   margin-top: 4px;
+//   padding-top: 10px;
+// }
+
+// .route-comment-content {
+//   white-space: normal;
+// }
+
+// .route-comment-author {
+//   margin-top: 5px;
+//   text-align: right;
+//   color: $text-gray;
+// }
+
+// .route-expanding-container {
+//   max-height: 0;
+//   transition: max-height 300ms ease-in-out;
+//   overflow: hidden;
+// }
+
+// .route-expanding-details {
+//   padding: 0 20px 20px 20px;
+// }

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -2,41 +2,62 @@
 @import "../../../../styles/colors.scss";
 @import "../../../../styles/variables.scss";
 
-// TODO: define inside variables...
-$gray: #757575;
-$gray-light: #ebebeb;
-$blue-very-light: #f6f9ff;
-
-mat-form-field {
-  width: 100%;
-}
-
 // fix options panel overflowing viewport on 100% wide mat-form-field
-::ng-deep .mat-select-panel-wrap {
-  div {
-    min-width: calc(100% + 32px) !important;
-  }
-}
+// TODO: check/test other occurences and move to global ?
+// TODO: check this again... maybe avoid losing time on this since we might be dropping material altogether...
+// ::ng-deep .mat-select-panel-wrap {
+//   div {
+//     min-width: calc(100% + 32px) !important;
+//   }
+// }
+// @media (min-width: $breakpoint-sm) {
+//   ::ng-deep .mat-select-panel-wrap {
+//     div {
+//       min-width: unset;
+//     }
+//   }
+// }
 
-@media (min-width: $breakpoint-sm) {
+.select-columns-and-sort-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  @media (min-width: $breakpoint-sm) {
+    flex-direction: row;
+    .max-half {
+      max-width: 50%;
+    }
+  }
+
   mat-form-field {
-    width: unset;
-  }
-
-  ::ng-deep .mat-select-panel-wrap {
-    div {
-      min-width: unset;
+    width: 100%;
+    &.hidden {
+      display: none;
     }
   }
 }
 
-.mat-option {
-  .mat-icon {
+mat-option {
+  // icon inside mat-select should be smaller
+  mat-icon {
     font-size: 16px;
     width: 16px;
     height: 16px;
     margin-right: 4px;
   }
+
+  // disable unselecting name column as it would make no sense
+  &#name {
+    pointer-events: none;
+  }
+}
+
+// icons should be same height as line height for nicer alignment
+::ng-deep mat-icon.mat-icon {
+  font-size: 20px;
+  height: 20px;
+  width: 20px;
+  vertical-align: middle;
 }
 
 .sector-heading {
@@ -45,48 +66,31 @@ mat-form-field {
   margin-left: 16px;
 }
 
-.scroll-shadows-table-wrap {
-  position: relative;
-}
-
-.left-scroll-shadow,
-.right-scroll-shadow {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  background-color: black;
-  opacity: 0.1;
-  width: 0px;
-  transition: width 300ms;
-
-  &.show {
-    width: 10px;
-  }
-}
-.left-scroll-shadow {
-  left: 0;
-}
-.right-scroll-shadow {
-  right: 0;
-}
-
-.table-wrap {
-  overflow-x: auto;
-  max-width: 100%;
-  flex-grow: 1;
-  background-color: white;
-  display: flex;
+.shadow {
+  box-shadow: $card-shadow;
 }
 
 table {
+  background-color: white;
   width: 100%;
+  border-collapse: separate;
 
   tr {
-    height: 53px;
+    height: 42px;
+  }
+
+  thead tr {
+    height: 48px;
+    position: sticky;
+    top: 0;
+    background-color: white;
+    z-index: 2;
   }
 
   tbody tr {
-    border-top: 1px solid $gray-light;
+    &:not(.details-row) {
+      cursor: pointer;
+    }
     &:hover:not(.details-row) {
       background-color: $blue-very-light;
     }
@@ -96,7 +100,7 @@ table {
   th {
     padding: 8px;
     text-align: left;
-    font-weight: normal;
+    font-weight: 400;
 
     &.checkbox {
       padding-left: 12px;
@@ -110,12 +114,12 @@ table {
         margin-top: -4px;
       }
     }
+
     &.name {
       padding-left: 0;
     }
+
     &.icon {
-      padding-left: 0;
-      padding-right: 0;
       text-align: center;
     }
   }
@@ -124,48 +128,29 @@ table {
     color: $gray;
     vertical-align: bottom;
     white-space: nowrap;
+    border-bottom: 1px solid $gray-light;
 
     &.checkbox {
       width: 40px;
       min-width: 40px;
     }
-
-    &.name {
-      min-width: 200px;
-    }
-    &.icon {
-      width: 40px;
-      min-width: 40px;
-    }
-
-    &.length {
-      width: 85px;
-    }
-    &.grade {
-      width: 103px;
-    }
-    &.nr-ticks {
-      width: 118px;
-    }
-    &.nr-tries {
-      width: 100px;
-    }
-    &.nr-climbers {
-      width: 99px;
-    }
   }
 
   td {
     vertical-align: middle;
-    &.icon {
-      padding: 0;
+    border-top: 1px solid $gray-light;
+  }
+
+  tbody tr:first-child {
+    td {
+      border: none;
     }
   }
 
   tbody tr.details-row {
     height: 0;
-    border: none;
     td {
+      border: none;
       height: 0;
       padding: 0;
     }
@@ -182,166 +167,84 @@ table {
   padding: 0 20px 20px 20px;
 }
 
-///
-// Keep old styles as a reference until mobile/narrow view is solved
+.compact {
+  background-color: white;
 
-// .route-row {
-//   display: flex;
-//   flex-direction: row;
-//   padding: 6px 2px 6px 16px;
-//   min-height: 43px;
+  .route {
+    display: flex;
+    align-items: center;
+    border-top: 1px solid $gray-light;
+    &:first-child {
+      border-top: none;
+    }
+    padding: 8px;
+    padding-left: 0;
 
-//   &.header {
-//     cursor: default;
-//     padding-top: 12px;
+    cursor: pointer;
+    &:hover {
+      background-color: $blue-very-light;
+    }
 
-//     @media (max-width: 959px) {
-//       display: none;
-//     }
-//   }
+    .checkbox {
+      flex: 0 0 40px;
+      text-align: center;
+    }
 
-//   .mat-checkbox {
-//     margin-top: -2px;
-//   }
-// }
+    .info-wrap {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
 
-// .route-details-container {
-//   flex: 1 1 100%;
-//   display: flex;
-//   flex-direction: row;
-//   justify-content: flex-start;
-//   align-items: center;
-//   text-align: left;
-// }
+      .info-row-first {
+        display: flex;
+        justify-content: flex-end;
+        align-items: center;
 
-// .route-details {
-//   display: flex;
-//   flex-direction: row;
-//   justify-content: flex-start;
-//   align-items: center;
+        .name {
+          flex: 1;
+          text-overflow: ellipsis;
+          overflow: hidden;
+          white-space: nowrap;
+        }
 
-//   &.left {
-//     flex: 1 1 100%;
+        .star {
+          margin-left: 4px;
+          display: flex;
+          align-items: center;
+        }
+      }
 
-//     @media (max-width: $breakpoint-sm) {
-//       // TODO use min-width instead
-//       display: flex;
-//       flex-direction: column;
-//       align-items: flex-start;
-//       justify-content: flex-start;
-//     }
-//   }
+      .info-row-second {
+        display: flex;
+        justify-content: space-between;
 
-//   &.right {
-//     flex: 0 0 110px;
-//   }
-// }
+        .grade-length-wrap {
+          display: flex;
 
-// .route-checkbox {
-//   flex: 0 0 12px;
-//   display: flex;
-//   align-items: center;
-//   justify-content: center;
-// }
+          .grade {
+            width: 40px;
+            margin-right: 4px;
+          }
+        }
 
-// .route-name {
-//   flex: 1 1 100%;
-// }
+        .multipitch-comments-my-ascents-wrap {
+          display: flex;
+        }
 
-// .route-numbers {
-//   // TODO take care of boulder places ... different width probably
-//   display: flex;
-//   flex: 0 0 200px;
+        .multipitch,
+        .comments,
+        .my-ascents {
+          flex: 0 0 20px;
+          width: 20px;
+          height: 20px;
+          margin-left: 4px;
+        }
+      }
 
-//   @media (max-width: $breakpoint-sm) {
-//     // TODO use min-width instead
-//     flex-direction: row;
-//     flex: 1 1 auto;
-//   }
-// }
-
-// .route-length {
-//   flex: 0 0 80px;
-//   height: 20px;
-// }
-
-// .route-grade {
-//   flex: 0 0 120px;
-//   position: relative;
-// }
-
-// .route-pitches {
-//   flex: 0 0 80px;
-// }
-
-// .route-icons {
-//   flex: 0 0 110px;
-//   display: flex;
-//   flex-direction: row;
-//   justify-content: flex-end;
-//   align-items: center;
-//   white-space: nowrap;
-//   text-align: right;
-//   margin: -4px 0;
-
-//   .mat-button {
-//     color: #0000008a;
-//   }
-
-//   .mat-icon-button {
-//     color: #0000008a;
-//     height: 37px;
-//     width: 37px;
-//   }
-// }
-
-// h3 {
-//   padding-top: 28px;
-// }
-
-// .ascent-type-filler {
-//   width: 36px;
-//   display: inline-block;
-// }
-
-// .difficulty-vote-included {
-//   font-weight: bold;
-// }
-
-// .difficulty-vote-author {
-//   padding-right: 20px;
-// }
-
-// .grade {
-//   width: 50px;
-//   display: block;
-// }
-
-// .difficulty-vote-date {
-//   text-align: right;
-// }
-
-// .route-comment:not(.first) {
-//   margin-top: 4px;
-//   padding-top: 10px;
-// }
-
-// .route-comment-content {
-//   white-space: normal;
-// }
-
-// .route-comment-author {
-//   margin-top: 5px;
-//   text-align: right;
-//   color: $text-gray;
-// }
-
-// .route-expanding-container {
-//   max-height: 0;
-//   transition: max-height 300ms ease-in-out;
-//   overflow: hidden;
-// }
-
-// .route-expanding-details {
-//   padding: 0 20px 20px 20px;
-// }
+      .info-row-third {
+        font-size: 12px;
+      }
+    }
+  }
+}

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -157,16 +157,6 @@ table {
   }
 }
 
-.route-expanding-container {
-  max-height: 0;
-  transition: max-height 225ms cubic-bezier(0.4, 0, 0.2, 1);
-  overflow: hidden;
-}
-
-.route-expanding-details {
-  padding: 0 20px 20px 20px;
-}
-
 .compact {
   background-color: white;
 
@@ -247,4 +237,14 @@ table {
       }
     }
   }
+}
+
+.route-expanding-container {
+  max-height: 0;
+  transition: max-height 225ms cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.selected {
+  background-color: $blue-very-light;
 }

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -24,13 +24,11 @@
   gap: 16px;
   @media (min-width: $breakpoint-sm) {
     flex-direction: row;
-    .max-half {
-      max-width: 50%;
-    }
   }
 
   mat-form-field {
     width: 100%;
+    min-width: 0;
     &.hidden {
       display: none;
     }

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -74,7 +74,11 @@ table {
   border-collapse: separate;
 
   tr {
-    height: 42px;
+    // +1 to accomodate top border on tds (except 1st row which 'uses' border of th)
+    height: 43px;
+    &:first-child {
+      height: 42px;
+    }
   }
 
   thead tr {

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -33,13 +33,11 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
     someRoutesShown: boolean;
   })[] = [];
 
+  // Provide some sensible default
   shownColumns = [
     'name',
     'length',
     'difficulty',
-    // 'nrTicks',
-    // 'nrTries',
-    // 'nrClimbers',
     'starRating',
     'multipitch',
     'comments',
@@ -144,6 +142,9 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit(): void {
+    if (sessionStorage.getItem('shownColumns')) {
+      this.shownColumns = JSON.parse(sessionStorage.getItem('shownColumns'));
+    }
     this.recalculateTableWidth();
 
     this.hostResizeObserver = new ResizeObserver((entries) => {
@@ -186,6 +187,11 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
     this.snackBar.dismiss();
     this.hostResizeObserver.disconnect();
     this.searchSub.unsubscribe();
+  }
+
+  onSelectedColumnsSelectionChange() {
+    sessionStorage.setItem('shownColumns', JSON.stringify(this.shownColumns));
+    this.recalculateTableWidth();
   }
 
   recalculateTableWidth() {

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -145,6 +145,15 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
     if (sessionStorage.getItem('shownColumns')) {
       this.shownColumns = JSON.parse(sessionStorage.getItem('shownColumns'));
     }
+
+    // Hide length column if crag has only boulders
+    if (this.crag.sectors.every((sector) => sector.bouldersOnly)) {
+      delete this.allColumns.length;
+      this.shownColumns = this.shownColumns.filter(
+        (column) => column != 'length'
+      );
+    }
+
     this.recalculateTableWidth();
 
     this.hostResizeObserver = new ResizeObserver((entries) => {

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -1,4 +1,5 @@
 import {
+  AfterViewInit,
   ChangeDetectorRef,
   Component,
   Input,
@@ -12,15 +13,96 @@ import { SnackBarButtonsComponent } from 'src/app/shared/snack-bar-buttons/snack
 import { LocalStorageService } from 'src/app/services/local-storage.service';
 import dayjs from 'dayjs';
 import ActivitySelection from 'src/app/types/activity-selection.interface';
-import { Crag, MyCragSummaryGQL, Route } from 'src/generated/graphql';
+import { Crag, MyCragSummaryGQL, Route, Sector } from 'src/generated/graphql';
+import { KeyValue } from '@angular/common';
 
 @Component({
   selector: 'app-crag-routes',
   templateUrl: './crag-routes.component.html',
   styleUrls: ['./crag-routes.component.scss'],
 })
-export class CragRoutesComponent implements OnInit, OnDestroy {
+export class CragRoutesComponent implements OnInit, OnDestroy, AfterViewInit {
   @Input() crag: Crag;
+
+  sectors: (Sector & {
+    sortedDirection?: number;
+    sortedField?: string;
+    showLeftShadow?: boolean;
+    showRightShadow?: boolean;
+  })[] = [];
+
+  edgeObservers: IntersectionObserver[] = [];
+
+  shownColumns = [
+    'name',
+    'length',
+    'difficulty',
+    // 'nrTicks',
+    // 'nrTries',
+    // 'nrClimbers',
+    'multipitch',
+    'comments',
+    'myAscents',
+  ];
+  allColumns = {
+    name: {
+      field: 'name',
+      selectLabel: 'Ime',
+      tableLabel: 'Ime',
+      defaultSortDirection: 1,
+    },
+    length: {
+      field: 'length',
+      selectLabel: 'Dolžina',
+      tableLabel: 'Dolžina',
+      defaultSortDirection: 1,
+    },
+    difficulty: {
+      field: 'difficulty',
+      selectLabel: 'Težavnost',
+      tableLabel: 'Težavnost',
+      defaultSortDirection: 1,
+    },
+    nrTicks: {
+      field: 'nrTicks',
+      selectLabel: 'Število uspešnih vzponov',
+      tableLabel: 'Uspešnih vzponov',
+      defaultSortDirection: -1,
+    },
+    nrTries: {
+      field: 'nrTries',
+      selectLabel: 'Število poskusov',
+      tableLabel: 'Poskusov',
+      defaultSortDirection: -1,
+    },
+    nrClimbers: {
+      field: 'nrClimbers',
+      selectLabel: 'Število plezalcev',
+      tableLabel: 'Plezalcev',
+      defaultSortDirection: -1,
+    },
+    starRating: {
+      field: 'starRating',
+      selectLabel: 'Lepota smeri',
+      defaultSortDirection: -1,
+    },
+    multipitch: {
+      field: 'multipitch',
+      selectLabel: 'Večraztežajna smer',
+      defaultSortDirection: -1,
+    },
+    comments: {
+      field: 'comments',
+      selectLabel: 'Smer ima komentarje',
+      defaultSortDirection: -1,
+    },
+    myAscents: {
+      field: 'myAscents',
+      selectLabel: 'Moji vzponi',
+      defaultSortDirection: -1,
+    },
+  };
+  math = Math;
 
   selectedRoutes: Route[] = [];
   selectedRoutesIds: string[] = [];
@@ -41,7 +123,48 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
     private changeDetection: ChangeDetectorRef
   ) {}
 
+  ngAfterViewInit() {
+    // Show/hide scroll shadows
+    this.sectors.forEach((sector) => {
+      const leftEdgeTarget = document.querySelector('#leftEdge' + sector.id);
+      const rightEdgeTarget = document.querySelector('#rightEdge' + sector.id);
+      const rootScrollArea = document.querySelector(
+        '#sectorTableWrap' + sector.id
+      );
+      const observerOptions = {
+        root: rootScrollArea,
+        rootMargin: '1px', // if margin=0, right side sometimes fails to intersect. missing a pixel?
+        threshold: 1,
+      };
+      const leftEdgeObserver = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          sector.showLeftShadow = false;
+        } else {
+          sector.showLeftShadow = true;
+        }
+      }, observerOptions);
+      const rightEdgeObserver = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          sector.showRightShadow = false;
+        } else {
+          sector.showRightShadow = true;
+        }
+      }, observerOptions);
+
+      leftEdgeObserver.observe(leftEdgeTarget);
+      rightEdgeObserver.observe(rightEdgeTarget);
+
+      this.edgeObservers.push(leftEdgeObserver);
+      this.edgeObservers.push(rightEdgeObserver);
+    });
+  }
+
   ngOnInit(): void {
+    // Make a copy (original is readonly and cannot be sorted)
+    this.crag.sectors.forEach((sector) => {
+      this.sectors.push({ ...sector, routes: [...sector.routes] });
+    });
+
     this.section = this.router.url.includes('/alpinizem/stena')
       ? 'alpinism'
       : 'sport';
@@ -65,6 +188,62 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.snackBar.dismiss();
+
+    this.edgeObservers.forEach((observer) => observer.disconnect());
+  }
+
+  sortRoutes(sectorIndex: number, sortField: string) {
+    if (sortField === 'position') {
+      // sorting by position is always asc (left to right), sorting by any other field inverts direction on each click
+      this.sectors[sectorIndex].sortedDirection = 1;
+    } else {
+      this.sectors[sectorIndex].sortedDirection =
+        this.sectors[sectorIndex].sortedField === sortField
+          ? this.sectors[sectorIndex].sortedDirection * -1
+          : this.allColumns[sortField].defaultSortDirection ?? 1;
+    }
+
+    this.sectors[sectorIndex].sortedField = sortField;
+
+    this.sectors[sectorIndex].routes.sort((r1, r2) => {
+      switch (this.sectors[sectorIndex].sortedField) {
+        case 'difficulty':
+          if (r1.isProject && r2.isProject) return 0;
+          if (r1.isProject) return this.sectors[sectorIndex].sortedDirection;
+          if (r2.isProject)
+            return this.sectors[sectorIndex].sortedDirection * -1;
+          break;
+
+        case 'multipitch':
+          if (r1.pitches.length && r2.pitches.length) return 0;
+          if (r1.pitches.length)
+            return this.sectors[sectorIndex].sortedDirection;
+          if (r2.pitches.length)
+            return this.sectors[sectorIndex].sortedDirection * -1;
+          return 0;
+
+        case 'comments':
+          if (r1.comments.length && r2.comments.length) return 0;
+          if (r1.comments.length)
+            return this.sectors[sectorIndex].sortedDirection;
+          if (r2.comments.length)
+            return this.sectors[sectorIndex].sortedDirection * -1;
+          return 0;
+
+        case 'myAscents':
+          if (this.ascents[r1.id] && this.ascents[r2.id]) return 0;
+          if (this.ascents[r1.id])
+            return this.sectors[sectorIndex].sortedDirection;
+          if (this.ascents[r2.id])
+            return this.sectors[sectorIndex].sortedDirection * -1;
+          return 0;
+      }
+
+      // default sort mode:
+      return r1[sortField] < r2[sortField]
+        ? this.sectors[sectorIndex].sortedDirection * -1
+        : this.sectors[sectorIndex].sortedDirection;
+    });
   }
 
   onCheckBoxClick(event: Event) {
@@ -190,4 +369,9 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
     this.expandedRowHeight = height;
     this.changeDetection.detectChanges();
   }
+
+  // Preserve original property order, when using keyvalue pipe in template
+  originalOrder = (a: KeyValue<any, any>, b: KeyValue<any, any>): number => {
+    return 0;
+  };
 }

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -378,10 +378,6 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
   }
 
   onPreviewHeightEvent(height: number): void {
-    if (height !== 0) {
-      height += 20; // for the 20px padding above the content
-    }
-
     this.expandedRowHeight = height;
     this.changeDetection.detectChanges();
   }

--- a/src/app/pages/crag/crag.component.html
+++ b/src/app/pages/crag/crag.component.html
@@ -43,7 +43,7 @@
     fxLayoutGap="16px"
     fxLayout.lt-md="column"
   >
-    <div fxFlex="33.33%" fxFlex.lt-md *ngIf="crag">
+    <div fxFlex="0 0 calc(33.33% - 8px)" fxFlex.lt-md *ngIf="crag">
       <nav mat-tab-nav-bar fxHide.lt-md>
         <a mat-tab-link disabled>Info</a>
       </nav>
@@ -58,7 +58,8 @@
     </div>
 
     <div
-      fxFlex="66.67%"
+      fxFlex="0 0 calc(66.67% - 8px)"
+      fxFlex.lt-md
       fxLayout="column"
       fxLayoutGap="0px"
       fxLayoutGap.lt-md="16px"

--- a/src/app/pages/crag/crag.component.html
+++ b/src/app/pages/crag/crag.component.html
@@ -57,7 +57,12 @@
       ></app-crag-image>
     </div>
 
-    <div fxFlex fxLayout="column" fxLayoutGap="0px" fxLayoutGap.lt-md="16px">
+    <div
+      fxFlex="66.67%"
+      fxLayout="column"
+      fxLayoutGap="0px"
+      fxLayoutGap.lt-md="16px"
+    >
       <nav mat-tab-nav-bar fxHide.lt-md>
         <ng-container *ngFor="let tab of tabs">
           <a

--- a/src/app/pages/crag/crag.component.ts
+++ b/src/app/pages/crag/crag.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { DataError } from 'src/app/types/data-error';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LayoutService } from 'src/app/services/layout.service';
-import { Subject, Subscription, take } from 'rxjs';
+import { Subject, Subscription } from 'rxjs';
 import { Tab } from '../../types/tab';
 import { AuthService } from 'src/app/auth/auth.service';
 import { MatDialog } from '@angular/material/dialog';

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -3,6 +3,41 @@
 
 <div *ngIf="!error" [class.not-visible]="loading">
   <div class="container mt-16">
+    <mat-card class="announcement-card mt-16 mb-32">
+      <div class="date">4.6.2022</div>
+      <h2>
+        Število vzponov, lepota smeri in poljubni stolpci ter razvrščanje in
+        filtriranje smeri v seznamu
+      </h2>
+      <p>Na seznam smeri smo dodali naslednje podatke o smereh:</p>
+      <ul>
+        <li>število vseh uspešnih vzponov v smeri,</li>
+        <li>število vseh poskusov v smeri (uspešnih in neuspešnih),</li>
+        <li>
+          število vseh plezalcev, ki so (uspešno ali neuspešno) plezali smer,
+        </li>
+        <li>lepota smeri (zvezdice).</li>
+      </ul>
+      <p>
+        Stolpce seznama lahko poljubno prikažeš ali skriješ tako, da jih označiš
+        ali odznačiš v spustnem seznamu.
+      </p>
+      <p>
+        Seznam smeri lahko razvrstiš po kateremkoli stolpcu s klikom na ime
+        stolpca (na večjih zaslonih) ali z izbiro iz spustnega seznama (na
+        manjših zaslonih).
+      </p>
+      <p>
+        Na večjih plezališčih, kjer so seznami smeri dolgi, lahko iskano smer
+        odslej hitro poiščeš tako, da del imena smeri vneseš v iskalno polje nad
+        seznamom.
+      </p>
+      <p>
+        O preteklih novostih si preberi v
+        <a [routerLink]="['/dnevnik-sprememb']">dnevniku sprememb</a>.
+      </p>
+    </mat-card>
+
     <app-search></app-search>
 
     <app-exposed-warnings

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -2,14 +2,47 @@
 //   padding: 12px 24px 12px 24px;
 // }
 
+$light-gray: #0000008a;
+
 .not-visible {
   visibility: hidden;
 }
 
-.welcome-card {
+.announcement-card {
   border-radius: 0;
 }
 h3 {
   color: #2196f3;
   padding: 0 0 16px 0;
+}
+
+ul {
+  margin-bottom: 12px;
+  margin-top: -4px;
+  li {
+    list-style: circle;
+    list-style-position: inside;
+    padding-left: 16px;
+  }
+}
+$almost-black: rgba(0, 0, 0, 0.87);
+
+h2 {
+  color: $almost-black;
+  padding: 0;
+}
+
+.date {
+  color: $light-gray;
+}
+
+.test {
+  display: inline-block;
+  background-color: #2196f3;
+  color: white;
+  padding: 2px 8px;
+  border-radius: 9px;
+  /* margin-bottom: 8px; */
+  font-size: 12px;
+  font-weight: 500;
 }

--- a/src/app/pages/route/route-comments/route-comments.component.html
+++ b/src/app/pages/route/route-comments/route-comments.component.html
@@ -1,32 +1,34 @@
 <div #container>
   <h3
-    *ngIf="!previewMode || regularComments.length"
+    *ngIf="!previewMode"
     fxLayout="row"
     fxLayoutAlign="center center"
     fxLayout.lt-md="column"
   >
-    <span fxFlex="100">{{
-      previewMode ? "Najnovejši komentarji" : "Komentarji"
-    }}</span>
+    <span fxFlex="100">Komentarji</span>
     <div fxFlex>
-      <button
-        *ngIf="!previewMode"
-        (click)="addComment('add-comment')"
-        mat-button
-        color="primary"
-      >
+      <button (click)="addComment('add-comment')" mat-button color="primary">
         Dodaj komentar
       </button>
     </div>
   </h3>
-
+  <!-- simplify by having same title for all comment types on route comment previews... -->
+  <h4
+    *ngIf="
+      previewMode &&
+      (regularComments.length || conditions.length || descriptions.length)
+    "
+  >
+    Najnovejši komentarji
+  </h4>
   <div
     *ngFor="let comment of regularComments | slice: 0:(previewMode ? 3 : 1000)"
     class="comment"
+    [class.preview]="previewMode"
     fxLayout="column"
     fxLayoutGap="8px"
   >
-    <app-comment [comment]="comment"></app-comment>
+    <app-comment [comment]="comment" [previewMode]="previewMode"></app-comment>
   </div>
   <div *ngIf="!regularComments.length && !previewMode" class="p-16">
     Ta smer nima še nobenega komentarja.
@@ -52,10 +54,14 @@
   <div
     *ngFor="let conditionComment of conditions"
     class="comment"
+    [class.preview]="previewMode"
     fxLayout="column"
     fxLayoutGap="8px"
   >
-    <app-comment [comment]="conditionComment"></app-comment>
+    <app-comment
+      [comment]="conditionComment"
+      [previewMode]="previewMode"
+    ></app-comment>
   </div>
 
   <h3
@@ -82,9 +88,13 @@
   <div
     *ngFor="let description of descriptions"
     class="comment"
+    [class.preview]="previewMode"
     fxLayout="column"
     fxLayoutGap="8px"
   >
-    <app-comment [comment]="description"></app-comment>
+    <app-comment
+      [comment]="description"
+      [previewMode]="previewMode"
+    ></app-comment>
   </div>
 </div>

--- a/src/app/pages/route/route-comments/route-comments.component.scss
+++ b/src/app/pages/route/route-comments/route-comments.component.scss
@@ -1,0 +1,16 @@
+@import "../../../../styles/variables.scss";
+
+h4 {
+  font-size: 14px;
+  font-weight: 500;
+  color: $gray;
+  margin: 16px 0 0 0;
+}
+
+.preview {
+  border-bottom: 1px solid $gray-light;
+  &:last-child {
+    border-bottom: none;
+  }
+  padding: 16px 0 16px 0;
+}

--- a/src/app/pages/route/route-info/route-info.component.html
+++ b/src/app/pages/route/route-info/route-info.component.html
@@ -70,3 +70,19 @@
     [gradingSystemId]="route.defaultGradingSystem.id"
   ></app-route-grades>
 </div>
+
+<div class="card no-border">
+  <h2>Popularnost smeri</h2>
+  <div class="row" fxLayout="row" fxLayoutAlign="space-between center">
+    <div class="label">Število uspešnih vzponov</div>
+    <span class="text-right">{{ route.nrTicks }}</span>
+  </div>
+  <div class="row" fxLayout="row" fxLayoutAlign="space-between center">
+    <div class="label">Število poskusov v smeri</div>
+    <span class="text-right">{{ route.nrTries }}</span>
+  </div>
+  <div class="row" fxLayout="row" fxLayoutAlign="space-between center">
+    <div class="label">Število plezalcev</div>
+    <span class="text-right">{{ route.nrClimbers }}</span>
+  </div>
+</div>

--- a/src/app/pages/route/route-info/route-info.component.scss
+++ b/src/app/pages/route/route-info/route-info.component.scss
@@ -2,6 +2,7 @@
 
 .card {
   margin-bottom: 16px;
+  overflow: auto;
 }
 
 .label {
@@ -19,4 +20,12 @@
 .difficulty-votes-chart {
   display: block;
   margin-bottom: 8px;
+}
+
+h2 {
+  font-size: 16px;
+  color: black;
+  margin-left: 14px;
+  font-weight: 400;
+  margin-top: 16px;
 }

--- a/src/app/pages/route/route.query.graphql
+++ b/src/app/pages/route/route.query.graphql
@@ -75,5 +75,8 @@ query RouteBySlug($cragSlug: String!, $routeSlug: String!) {
         }
       }
     }
+    nrTicks
+    nrTries
+    nrClimbers
   }
 }

--- a/src/app/shared/components/ascent-type/ascent-type.component.html
+++ b/src/app/shared/components/ascent-type/ascent-type.component.html
@@ -1,11 +1,21 @@
-<ng-container *ngIf="displayType=='text'">
-  <span *ngIf="ascentType" [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)">{{ ascentType.label }}
-    <span class="toprope" *ngIf="topRope"> (top rope)</span></span>
-  <span *ngIf="ascentType == null"><i>{{ type }}</i></span>
+<ng-container *ngIf="displayType == 'text'">
+  <span
+    *ngIf="ascentType"
+    [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)"
+    >{{ ascentType.label }}
+    <span class="toprope" *ngIf="topRope"> (top rope)</span></span
+  >
+  <span *ngIf="ascentType == null"
+    ><i>{{ type }}</i></span
+  >
 </ng-container>
-<ng-container *ngIf="displayType=='icon'">
-  <span *ngIf="ascentType" [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)"
-    [matTooltip]="ascentType.label"><button mat-button>
+<ng-container *ngIf="displayType == 'icon'">
+  <span
+    *ngIf="ascentType"
+    [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)"
+    [matTooltip]="ascentType.label"
+    ><button mat-icon-button>
       <mat-icon>{{ icon }}</mat-icon>
-    </button></span>
+    </button></span
+  >
 </ng-container>

--- a/src/app/shared/components/ascent-type/ascent-type.component.html
+++ b/src/app/shared/components/ascent-type/ascent-type.component.html
@@ -10,12 +10,11 @@
   >
 </ng-container>
 <ng-container *ngIf="displayType == 'icon'">
-  <span
+  <mat-icon
     *ngIf="ascentType"
     [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)"
     [matTooltip]="ascentType.label"
-    ><button mat-icon-button>
-      <mat-icon>{{ icon }}</mat-icon>
-    </button></span
+    [title]="ascentType.label"
+    >{{ icon }}</mat-icon
   >
 </ng-container>

--- a/src/app/shared/components/ascent-type/ascent-type.component.scss
+++ b/src/app/shared/components/ascent-type/ascent-type.component.scss
@@ -9,7 +9,3 @@
 .color-red {
   color: $text-red;
 }
-.mat-button {
-  padding: 0;
-  min-width: 36px;
-}

--- a/src/app/shared/components/comment/comment.component.html
+++ b/src/app/shared/components/comment/comment.component.html
@@ -1,6 +1,6 @@
 <div
-  class="card padding comment"
-  [ngClass]="commentType"
+  class="padding comment {{ commentType }}"
+  [ngClass]="{ card: !previewMode, preview: previewMode }"
   fxLayout="column"
   fxLayoutGap="8px"
 >

--- a/src/app/shared/components/comment/comment.component.scss
+++ b/src/app/shared/components/comment/comment.component.scss
@@ -1,4 +1,5 @@
 @import "../../../../styles/colors.scss";
+@import "../../../../styles/variables.scss";
 
 .comment {
   margin-bottom: 16px;
@@ -7,8 +8,13 @@
   margin-bottom: 16px;
   border-left-color: $accent;
 }
+
+.preview {
+  margin-bottom: 0;
+}
+
 .author {
-  color: #00000080;
+  color: $gray;
   margin-bottom: -4px;
   > .actions {
     margin: -8px;

--- a/src/app/shared/components/comment/comment.component.ts
+++ b/src/app/shared/components/comment/comment.component.ts
@@ -11,6 +11,7 @@ import { Comment } from 'src/generated/graphql';
 export class CommentComponent implements OnInit, OnDestroy {
   @Input() comment: Comment;
   @Input() commentType: string;
+  @Input() previewMode = false;
 
   isAuthor = false;
 

--- a/src/app/shared/pipes/pluralize-noun.pipe.ts
+++ b/src/app/shared/pipes/pluralize-noun.pipe.ts
@@ -8,6 +8,46 @@ export class PluralizeNoun implements PipeTransform {
     switch (noun) {
       case 'smer':
         return count + (count % 100 === 1 ? ' smer' : ' smeri');
+
+      case 'uspešen vzpon':
+        switch (count % 100) {
+          case 1:
+            return `${count} uspešen vzpon`;
+          case 2:
+            return `${count} uspešna vzpona`;
+          case 3:
+          case 4:
+            return `${count} uspešni vzponi`;
+          default:
+            return `${count} uspešnih vzponov`;
+        }
+
+      case 'poskus':
+        switch (count % 100) {
+          case 1:
+            return `${count} poskus`;
+          case 2:
+            return `${count} poskusa`;
+          case 3:
+          case 4:
+            return `${count} poskusi`;
+          default:
+            return `${count} poskusov`;
+        }
+
+      case 'plezalec':
+        switch (count % 100) {
+          case 1:
+            return `${count} plezalec`;
+          case 2:
+            return `${count} plezalca`;
+          case 3:
+          case 4:
+            return `${count} plezalci`;
+          default:
+            return `${count} plezalcev`;
+        }
+
       // case 'xyz' // add nouns when needed...
       default:
         return count + ' ' + noun;

--- a/src/assets/icons/multipitch.svg
+++ b/src/assets/icons/multipitch.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <g id="Group_1" data-name="Group 1" transform="translate(-650 -298)">
+    <text id="MP" transform="translate(651.5 315)" font-size="14" font-family="Poppins-Medium, Poppins" font-weight="500"><tspan x="0" y="0">MP</tspan></text>    
+  </g>
+</svg>

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -74,6 +74,10 @@ body {
   margin-left: 16px;
 }
 
+.pb-8 {
+  padding-bottom: 8px;
+}
+
 .py-8 {
   padding-top: 8px;
   padding-bottom: 8px;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -70,6 +70,9 @@ body {
 .mb-32 {
   margin-bottom: 32px;
 }
+.ml-16 {
+  margin-left: 16px;
+}
 
 .py-8 {
   padding-top: 8px;
@@ -261,10 +264,6 @@ body {
   .mat-paginator {
     background: none;
   }
-}
-
-.star {
-  color: #dd0;
 }
 
 span.highlight {

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -2,3 +2,10 @@ $breakpoint-sm: 600px;
 $breakpoint-md: 905px;
 $breakpoint-lg: 1240px;
 $breakpoint-xl: 1440px;
+
+$gray: #757575;
+$gray-light: #ebebeb;
+$blue-very-light: #f6f9ff;
+$blue-light-semi-transparent: #314c8833;
+
+$card-shadow: 0 0 16px $blue-light-semi-transparent;


### PR DESCRIPTION
1.
Add  the following counts to the route page:
- number of ticks (successful ascents)
- number of tries (all failed + successful ascents)
- number of climbers (distinct people that tried the route)

2.
Adds option to select custom columns on crag route list. 
Added are:
- number of ticks (successful ascents)
- number of tries (all failed + successful ascents)
- number of climbers (distinct people that tried the route)
- star rating

All columns are sortable now.

3.
Adds compact view. It is switched to it when space runs out. Table never gets horizontal scroll now.
Headers are sticky in table view.

TODO: 

- [x] save default columns to user settings (or localstorage?) per crag?
- [ ] merge/separate sectors on sort (checkbox user option)
- [x] update/rework accordion layout/design


EXTRAS:
- spelling mistake in log form footnote fixed
- previews of comments and votes in accordions -> adjusted layout





Test with https://github.com/plezanje-net/api/pull/113

closes #347 
closes #348 
closes #364 
