### PR TITLE
Hide latest images on homepage until image upload is implemented.

### DIFF
--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -11,7 +11,7 @@
 
     <app-popular-crags (errorEvent)="handleError($event)"></app-popular-crags>
 
-    <app-latest-images (errorEvent)="handleError($event)"></app-latest-images>
+    <!-- <app-latest-images (errorEvent)="handleError($event)"></app-latest-images> -->
 
     <app-latest-ticks (errorEvent)="handleError($event)"></app-latest-ticks>
   </div>


### PR DESCRIPTION
I suggest we hide this from homepage for now and reenable it when image upload is finished. 
To test: open homepage :)

