### PR TITLE
Fix icon styles spilling from route list.

### DIFF
--- a/src/app/common/sortable-header-field/sortable-header-field.component.scss
+++ b/src/app/common/sortable-header-field/sortable-header-field.component.scss
@@ -10,14 +10,21 @@ div {
   justify-content: center;
 }
 
-mat-icon.sort-arrow {
-  &:last-child {
-    margin-left: -6px;
-  }
+mat-icon.mat-icon {
+  font-size: 20px;
+  height: 20px;
+  width: 20px;
+  vertical-align: middle;
 
-  font-size: 12px;
-  width: 12px;
-  height: 12px;
+  &.sort-arrow {
+    &:last-child {
+      margin-left: -6px;
+    }
+
+    font-size: 12px;
+    width: 12px;
+    height: 12px;
+  }
 }
 
 .active {

--- a/src/app/pages/crag/crag-routes/crag-routes.component.scss
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.scss
@@ -51,7 +51,7 @@ mat-option {
 }
 
 // icons should be same height as line height for nicer alignment
-::ng-deep mat-icon.mat-icon {
+mat-icon.mat-icon {
   font-size: 20px;
   height: 20px;
   width: 20px;

--- a/src/app/shared/components/ascent-type/ascent-type.component.html
+++ b/src/app/shared/components/ascent-type/ascent-type.component.html
@@ -9,7 +9,7 @@
     ><i>{{ type }}</i></span
   >
 </ng-container>
-<ng-container *ngIf="displayType == 'icon'">
+<ng-container *ngIf="displayType === 'icon'">
   <mat-icon
     *ngIf="ascentType"
     [ngClass]="'color-' + (topRope ? 'yellow' : ascentType.color)"

--- a/src/app/shared/components/ascent-type/ascent-type.component.scss
+++ b/src/app/shared/components/ascent-type/ascent-type.component.scss
@@ -9,3 +9,10 @@
 .color-red {
   color: $text-red;
 }
+
+mat-icon.mat-icon {
+  font-size: 20px;
+  height: 20px;
+  width: 20px;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Styles in route list had some ng-deep which was making styles spill to other components...
To test> 
on master see the problem by navigating to route list and observe the avatar icon in header becoming too small.
on this branch see that the problem is fixed

