### PR TITLE
Show user's private activity routes notes on log.

### DIFF
--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
@@ -129,13 +129,14 @@
     </div>
   </div>
   <div>
-    <mat-form-field fxFlex="100" class="no-hint">
-      <mat-label>Komentar</mat-label>
+    <mat-form-field fxFlex="100">
+      <mat-label>Opombe</mat-label>
       <textarea
         matInput
         formControlName="notes"
         [rows]="activity ? 3 : 6"
       ></textarea>
+      <mat-hint>Opombe bodo vidne samo tebi</mat-hint>
     </mat-form-field>
   </div>
   <div fxFlex fxLayout="row" fxLayout.lt-sm="column" fxLayoutGap="16px">

--- a/src/app/activity/pages/activity-routes/activity-routes.component.ts
+++ b/src/app/activity/pages/activity-routes/activity-routes.component.ts
@@ -72,6 +72,7 @@ export class ActivityRoutesComponent implements OnInit, OnDestroy {
       { name: 'route', label: 'Smer' },
       { name: 'grade', label: 'Ocena', sortable: true },
       { name: 'ascentType', label: 'Vrsta vzpona' },
+      { name: 'notes', label: 'Opombe' },
       { name: 'publish', label: 'Vidnost' },
     ],
     [

--- a/src/app/activity/partials/activity-entry-routes/activity-entry-routes.component.html
+++ b/src/app/activity/partials/activity-entry-routes/activity-entry-routes.component.html
@@ -4,6 +4,7 @@
       <td>Smer</td>
       <td>Ocena</td>
       <td>Vrsta vzpona</td>
+      <td *ngIf="!noNotes">Opombe</td>
       <td>Vidnost</td>
       <td></td>
     </tr>
@@ -15,6 +16,7 @@
       [route]="route"
       [rowAction]="rowAction$"
       [displayType]="type == 'form' ? 'activityForm' : 'activity'"
+      [noNotes]="noNotes"
     ></tr>
   </table>
 </div>

--- a/src/app/activity/partials/activity-entry-routes/activity-entry-routes.component.scss
+++ b/src/app/activity/partials/activity-entry-routes/activity-entry-routes.component.scss
@@ -1,0 +1,7 @@
+.scrollable-table {
+  max-width: 100%;
+  overflow-x: auto;
+  .card-table {
+    min-width: 600px;
+  }
+}

--- a/src/app/activity/partials/activity-entry-routes/activity-entry-routes.component.ts
+++ b/src/app/activity/partials/activity-entry-routes/activity-entry-routes.component.ts
@@ -23,6 +23,8 @@ export class ActivityEntryRoutesComponent implements OnInit {
 
   rowAction$ = new Subject(); // source
 
+  noNotes = false;
+
   constructor(
     private deleteActivityRouteGQL: DeleteActivityRouteGQL,
     private router: Router,
@@ -33,6 +35,9 @@ export class ActivityEntryRoutesComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    // save some space by hiding notes column if there are none
+    this.noNotes = !this.routes.some((route) => route.notes);
+
     this.rowAction$.subscribe((action: any) => {
       switch (action.action) {
         case 'filterByCrag':

--- a/src/app/activity/partials/activity-route-row/activity-route-row.component.html
+++ b/src/app/activity/partials/activity-route-row/activity-route-row.component.html
@@ -43,11 +43,13 @@
 <td>
   <app-ascent-type [value]="route.ascentType"></app-ascent-type>
 </td>
+<td *ngIf="!noNotes">{{ route.notes }}</td>
 <td>
   <app-ascent-publish-option
     [value]="route.publish"
   ></app-ascent-publish-option>
 </td>
+
 <td *ngIf="rowAction" class="tools">
   <button mat-icon-button type="button" [mat-menu-trigger-for]="menu">
     <mat-icon>more_vert</mat-icon>

--- a/src/app/activity/partials/activity-route-row/activity-route-row.component.ts
+++ b/src/app/activity/partials/activity-route-row/activity-route-row.component.ts
@@ -17,6 +17,7 @@ export class ActivityRouteRowComponent implements OnInit {
   @Input() route: ActivityRoute;
   @Input() rowAction: Subject<RowAction>;
   @Input() displayType: 'activity' | 'activityForm' | 'routes' = 'routes';
+  @Input() noNotes = false;
   publishOptions = PUBLISH_OPTIONS;
 
   constructor(

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -203,7 +203,7 @@ b {
     height: 52px;
     td {
       vertical-align: middle;
-      padding: 0 12px;
+      padding: 8px 12px;
       &.tools {
         width: 10px;
         white-space: nowrap;


### PR DESCRIPTION
closes #380 
also closes #363 by making the table scrollable (should rework design of wide tables to avoid horizontal scrolls in a later task)
