### PR TITLE
Basic scroll restoration logic added and used on crags and crag pages.

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -139,7 +139,7 @@ const routes: Routes = [
 @NgModule({
   imports: [
     RouterModule.forRoot(routes, {
-      scrollPositionRestoration: 'top',
+      scrollPositionRestoration: 'disabled',
       // preloadingStrategy: PreloadAllModules,
     }),
   ],

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -12,6 +12,8 @@ import { Subscription, take } from 'rxjs';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material/icon';
 
+import { ScrollService } from './services/scroll.service';
+
 declare let gtag: Function;
 
 @Component({
@@ -31,7 +33,8 @@ export class AppComponent implements OnInit, OnDestroy {
     private router: Router,
     private layoutService: LayoutService,
     private matIconRegistry: MatIconRegistry,
-    private domSanitizer: DomSanitizer
+    private domSanitizer: DomSanitizer,
+    private scrollService: ScrollService
   ) {
     this.matIconRegistry.addSvgIcon(
       'multipitch',
@@ -90,6 +93,9 @@ export class AppComponent implements OnInit, OnDestroy {
       .subscribe(() => gtag('event', 'page_view'));
 
     this.subscriptions.push(routerSub);
+
+    this.scrollService.startCachingScrollPositions();
+    this.scrollService.enableDefaultScrollToTop();
   }
 
   ngOnDestroy(): void {

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -116,7 +116,7 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
   hostResizeObserver: ResizeObserver;
   routeListViewStyle: 'compact' | 'table';
   tableWidth: number;
-  availableWidth: number;
+  availableWidth: number = 0;
   sortAll = ['position', 1];
   search = new FormControl();
   searchSub: Subscription;

--- a/src/app/pages/crag/crag.component.ts
+++ b/src/app/pages/crag/crag.component.ts
@@ -104,14 +104,9 @@ export class CragComponent implements OnInit, OnDestroy {
       }
 
       this.cragSub = this.cragBySlugGQL
-        .watch(
-          {
-            crag: params.crag,
-          },
-          {
-            // fetchPolicy: 'no-cache', // TODO: this is a test
-          }
-        )
+        .watch({
+          crag: params.crag,
+        })
         .valueChanges.subscribe({
           next: (result) => {
             this.loading = false;

--- a/src/app/pages/crag/crag.component.ts
+++ b/src/app/pages/crag/crag.component.ts
@@ -15,6 +15,7 @@ import {
 } from 'src/generated/graphql';
 import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { User } from '@sentry/angular';
+import { ScrollService } from 'src/app/services/scroll.service';
 
 @Component({
   selector: 'app-crag',
@@ -68,7 +69,8 @@ export class CragComponent implements OnInit, OnDestroy {
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private cragBySlugGQL: CragBySlugGQL,
-    private breakpointObserver: BreakpointObserver
+    private breakpointObserver: BreakpointObserver,
+    private scrollService: ScrollService
   ) {}
 
   ngOnInit(): void {
@@ -102,9 +104,14 @@ export class CragComponent implements OnInit, OnDestroy {
       }
 
       this.cragSub = this.cragBySlugGQL
-        .watch({
-          crag: params.crag,
-        })
+        .watch(
+          {
+            crag: params.crag,
+          },
+          {
+            // fetchPolicy: 'no-cache', // TODO: this is a test
+          }
+        )
         .valueChanges.subscribe({
           next: (result) => {
             this.loading = false;
@@ -222,6 +229,8 @@ export class CragComponent implements OnInit, OnDestroy {
         `Plezališče ${this.crag.name}`,
         this.crag.country.name,
       ]);
+
+      this.scrollService.restoreScroll();
     }
   }
 

--- a/src/app/pages/crags/crags.component.ts
+++ b/src/app/pages/crags/crags.component.ts
@@ -9,6 +9,7 @@ import { FormControl } from '@angular/forms';
 import { ROUTE_TYPES } from 'src/app/common/route-types.constants';
 import { AuthService } from 'src/app/auth/auth.service';
 import { User } from '@sentry/angular';
+import { ScrollService } from 'src/app/services/scroll.service';
 
 @Component({
   selector: 'app-crags',
@@ -42,7 +43,8 @@ export class CragsComponent implements OnInit, OnDestroy {
     private layoutService: LayoutService,
     private activatedRoute: ActivatedRoute,
     private router: Router,
-    private cragsGQL: CragsGQL
+    private cragsGQL: CragsGQL,
+    private scrollService: ScrollService
   ) {}
 
   ngOnInit(): void {
@@ -159,6 +161,8 @@ export class CragsComponent implements OnInit, OnDestroy {
     ]);
 
     this.layoutService.setTitle(['Seznam plezališč', this.country.name]);
+
+    this.scrollService.restoreScroll();
   }
 
   ngOnDestroy(): void {

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -1,0 +1,63 @@
+import { ViewportScroller } from '@angular/common';
+import { Injectable, NgZone } from '@angular/core';
+import { NavigationStart, Router } from '@angular/router';
+import { asyncScheduler, filter, observeOn, take } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ScrollService {
+  scrollPositions: { [K: number]: number } = {}; // event id -> scroll position
+  lastEvent: NavigationStart;
+
+  constructor(
+    private router: Router,
+    private viewportScroller: ViewportScroller,
+    private zone: NgZone
+  ) {}
+
+  /**
+   * Subscribe to NavigationStart events and record all the scroll positions on which the user navigated away.
+   * Positions are indexed by the event id.
+   */
+  startCachingScrollPositions() {
+    console.log('starting caching scroll positions');
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationStart))
+      .subscribe((event: NavigationStart) => {
+        this.scrollPositions[event.id] =
+          this.viewportScroller.getScrollPosition()[1];
+        this.lastEvent = event; // Keep track of the last event to be able to be able to restore scroll position when restoreScroll is called
+      });
+  }
+
+  /**
+   * If this is enabled, components that do not make their own calls to restoreScroll will always scroll to the top.
+   */
+  enableDefaultScrollToTop() {
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationStart))
+      .subscribe((_event) => {
+        this.viewportScroller.scrollToPosition([0, 0]);
+      });
+  }
+
+  /**
+   * Schedule scroll position restoration. Should be done after all sync code completes and views are rendered in the DOM.
+   * This is expected to be called from components after they fetch their data.
+   */
+  restoreScroll() {
+    this.zone.onMicrotaskEmpty
+      .asObservable()
+      .pipe(take(1), observeOn(asyncScheduler))
+      .subscribe(() => {
+        // If this is a back or a forward click
+        if (this.lastEvent.navigationTrigger === 'popstate') {
+          this.viewportScroller.scrollToPosition([
+            0,
+            this.scrollPositions[this.lastEvent.restoredState.navigationId + 1],
+          ]);
+        }
+      });
+  }
+}

--- a/src/app/services/scroll.service.ts
+++ b/src/app/services/scroll.service.ts
@@ -1,7 +1,7 @@
 import { ViewportScroller } from '@angular/common';
-import { Injectable, NgZone } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { NavigationStart, Router } from '@angular/router';
-import { asyncScheduler, filter, observeOn, take } from 'rxjs';
+import { asyncScheduler, filter } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -12,8 +12,7 @@ export class ScrollService {
 
   constructor(
     private router: Router,
-    private viewportScroller: ViewportScroller,
-    private zone: NgZone
+    private viewportScroller: ViewportScroller
   ) {}
 
   /**
@@ -21,7 +20,6 @@ export class ScrollService {
    * Positions are indexed by the event id.
    */
   startCachingScrollPositions() {
-    console.log('starting caching scroll positions');
     this.router.events
       .pipe(filter((event) => event instanceof NavigationStart))
       .subscribe((event: NavigationStart) => {
@@ -47,17 +45,14 @@ export class ScrollService {
    * This is expected to be called from components after they fetch their data.
    */
   restoreScroll() {
-    this.zone.onMicrotaskEmpty
-      .asObservable()
-      .pipe(take(1), observeOn(asyncScheduler))
-      .subscribe(() => {
-        // If this is a back or a forward click
-        if (this.lastEvent.navigationTrigger === 'popstate') {
-          this.viewportScroller.scrollToPosition([
-            0,
-            this.scrollPositions[this.lastEvent.restoredState.navigationId + 1],
-          ]);
-        }
-      });
+    asyncScheduler.schedule(() => {
+      // If this is a back or a forward click
+      if (this.lastEvent.navigationTrigger === 'popstate') {
+        this.viewportScroller.scrollToPosition([
+          0,
+          this.scrollPositions[this.lastEvent.restoredState.navigationId + 1],
+        ]);
+      }
+    });
   }
 }


### PR DESCRIPTION
To test this out go to a crag, navigate to a route, then click browser back button. scroll position should be restored.

Thoroughly test by clicking back forward multiple times...
It should work on: 
- routes list
- crags list

closes #355 
