### PR TITLE
Enable editing base difficulty on routes with base diff vote only.

### DIFF
--- a/src/app/management/forms/route-form/route-form.component.html
+++ b/src/app/management/forms/route-form/route-form.component.html
@@ -56,10 +56,10 @@
     fxLayout.lt-md="column"
     fxLayoutAlign.lt-md="stretch"
   >
-    <div fxLayout="column" fxFlex *ngIf="!editing">
+    <div fxLayout="column" fxFlex>
       <mat-checkbox formControlName="isProject">Smer je projekt</mat-checkbox>
     </div>
-    <div fxFlex *ngIf="!editing && !form.value.isProject">
+    <div fxFlex>
       <app-grade-select
         fxFlex
         label="Bazna ocena"

--- a/src/app/management/forms/route-form/route-form.component.ts
+++ b/src/app/management/forms/route-form/route-form.component.ts
@@ -191,10 +191,15 @@ export class RouteFormComponent implements OnInit, OnDestroy {
     }
   }
 
+  /**
+   * Base grade of a route can be edited only if no user votes have been cast yet and no ascent has been recorded yet.
+   */
   private baseDifficultyEditable(route: Route) {
     return (
-      route?.difficultyVotes.length == 0 ||
-      (route?.difficultyVotes.length == 1 && route?.difficultyVotes[0].isBase)
+      (route?.difficultyVotes.length == 0 ||
+        (route?.difficultyVotes.length == 1 &&
+          route?.difficultyVotes[0].isBase)) &&
+      route.nrTries === 0
     );
   }
 
@@ -226,8 +231,6 @@ export class RouteFormComponent implements OnInit, OnDestroy {
 
     const success = () => {
       this.apollo.client.resetStore().then(() => {
-        this.saving = false;
-
         const { routeTypeId, defaultGradingSystemId, status, position } = value;
 
         this.dialogRef.close(
@@ -244,6 +247,7 @@ export class RouteFormComponent implements OnInit, OnDestroy {
       });
     };
     const error = () => {
+      this.dialogRef.close();
       this.snackbar.open('Pri shranjevanju je prišlo do napake', null, {
         panelClass: 'error',
         duration: 3000,

--- a/src/app/management/pages/crag-sector-routes/management-get-sector.query.graphql
+++ b/src/app/management/pages/crag-sector-routes/management-get-sector.query.graphql
@@ -52,6 +52,7 @@ query ManagementGetSector($id: String!) {
       user {
         id
       }
+      nrTries
     }
   }
 }

--- a/src/app/pages/route/route-grades/route-grades.component.html
+++ b/src/app/pages/route/route-grades/route-grades.component.html
@@ -13,8 +13,10 @@
       [legacy]="true"
     ></app-grade>
     <div>
-      <ng-container *ngIf="grade.isBase">Bazna ocena</ng-container>
-      <ng-container *ngIf="!grade.isBase && grade.user"
+      <ng-container *ngIf="grade.isBase && !grade.user"
+        >Bazna ocena</ng-container
+      >
+      <ng-container *ngIf="grade.user"
         >{{ grade.user.firstname + " " + grade.user.lastname }}
       </ng-container>
     </div>


### PR DESCRIPTION
Project checkbox and base difficulty fields are left on the form always, but disabled when not editable.

To test try many combinations -> only routes with no user diff votes should have editable base difficulties.

There is a slight inconvenience on editing routes with legacy 'half' base difficulties.

Discussion on how to tackle this is ongoing,...

test with https://github.com/plezanje-net/api/pull/119

also closes #338 