### PR TITLE
set html type on email inputs

### DIFF
--- a/src/app/auth/login/login.component.html
+++ b/src/app/auth/login/login.component.html
@@ -6,7 +6,7 @@
     <p>
       <mat-form-field class="no-hint">
         <mat-label>E-naslov</mat-label>
-        <input matInput type="text" formControlName="email" />
+        <input matInput type="email" formControlName="email" />
       </mat-form-field>
     </p>
     <p>

--- a/src/app/auth/password-recovery/password-recovery.component.html
+++ b/src/app/auth/password-recovery/password-recovery.component.html
@@ -4,7 +4,7 @@
     <p>
       <mat-form-field class="no-hint">
         <mat-label>E-naslov</mat-label>
-        <input matInput type="text" formControlName="email" />
+        <input matInput type="email" formControlName="email" />
       </mat-form-field>
     </p>
 

--- a/src/app/pages/account/register/register.component.html
+++ b/src/app/pages/account/register/register.component.html
@@ -17,6 +17,7 @@
             <mat-label>E-naslov</mat-label>
             <input
               matInput
+              type="email"
               formControlName="email"
               id="email"
               autocomplete="email"


### PR DESCRIPTION
changing html types from text to email disables autocapitalise on mobile

tested on xcode's iphone simulator

bonus for issue https://github.com/plezanje-net/api/issues/117