### PR TITLE
Fix search

### DIFF
--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -18,6 +18,7 @@ import { KeyValue } from '@angular/common';
 import { MatSelectChange } from '@angular/material/select';
 import { FormControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
+import { SearchService } from 'src/app/shared/services/search.service';
 
 @Component({
   selector: 'app-crag-routes',
@@ -138,7 +139,8 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
     private myCragSummaryGQL: MyCragSummaryGQL,
     private localStorageService: LocalStorageService,
     private changeDetection: ChangeDetectorRef,
-    private hostElement: ElementRef
+    private hostElement: ElementRef,
+    private searchService: SearchService
   ) {}
 
   ngOnInit(): void {
@@ -291,9 +293,8 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
   filterRoutes(): void {
     let searchTerm = this.search.value;
     searchTerm = searchTerm.toLowerCase();
-    searchTerm = searchTerm.replace(/[cčć]/gi, '[cčć]');
-    searchTerm = searchTerm.replace(/[sš]/gi, '[sš]');
-    searchTerm = searchTerm.replace(/[zž]/gi, '[zž]');
+    searchTerm = this.searchService.ignoreAccents(searchTerm);
+
     const regExp = new RegExp(searchTerm);
 
     this.sectors.forEach((sector) =>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -293,6 +293,7 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
   filterRoutes(): void {
     let searchTerm = this.search.value;
     searchTerm = searchTerm.toLowerCase();
+    searchTerm = this.searchService.escape(searchTerm);
     searchTerm = this.searchService.ignoreAccents(searchTerm);
 
     const regExp = new RegExp(searchTerm);

--- a/src/app/pages/crags/crags.component.ts
+++ b/src/app/pages/crags/crags.component.ts
@@ -111,6 +111,7 @@ export class CragsComponent implements OnInit, OnDestroy {
     } else {
       let searchTerm = this.search.value;
       searchTerm = searchTerm.toLowerCase();
+      searchTerm = this.searchService.escape(searchTerm);
       searchTerm = this.searchService.ignoreAccents(searchTerm);
 
       const regExp = new RegExp(searchTerm);

--- a/src/app/pages/crags/crags.component.ts
+++ b/src/app/pages/crags/crags.component.ts
@@ -10,6 +10,7 @@ import { ROUTE_TYPES } from 'src/app/common/route-types.constants';
 import { AuthService } from 'src/app/auth/auth.service';
 import { User } from '@sentry/angular';
 import { ScrollService } from 'src/app/services/scroll.service';
+import { SearchService } from 'src/app/shared/services/search.service';
 
 @Component({
   selector: 'app-crags',
@@ -44,7 +45,8 @@ export class CragsComponent implements OnInit, OnDestroy {
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private cragsGQL: CragsGQL,
-    private scrollService: ScrollService
+    private scrollService: ScrollService,
+    private searchService: SearchService
   ) {}
 
   ngOnInit(): void {
@@ -109,9 +111,8 @@ export class CragsComponent implements OnInit, OnDestroy {
     } else {
       let searchTerm = this.search.value;
       searchTerm = searchTerm.toLowerCase();
-      searchTerm = searchTerm.replace(/[cčć]/gi, '[cčć]');
-      searchTerm = searchTerm.replace(/[sš]/gi, '[sš]');
-      searchTerm = searchTerm.replace(/[zž]/gi, '[zž]');
+      searchTerm = this.searchService.ignoreAccents(searchTerm);
+
       const regExp = new RegExp(searchTerm);
 
       this.filteredCrags = this.country.crags.filter((crag) =>

--- a/src/app/pages/search/search-results/search-results.component.html
+++ b/src/app/pages/search/search-results/search-results.component.html
@@ -37,7 +37,11 @@
             </div>
             <div
               *ngFor="let crag of searchResults.crags"
-              [routerLink]="['/plezalisce', crag.slug]"
+              [routerLink]="
+                crag.type == 'alpine'
+                  ? ['/alpinizem/stena', crag.slug]
+                  : ['/plezalisce', crag.slug]
+              "
               fxLayout="row"
               fxLayoutAlign="start center"
               fxLayoutGap="5px"
@@ -96,12 +100,11 @@
               fxLayoutAlign="start center"
               fxLayoutGap="5px"
               class="row"
-              [routerLink]="[
-                '/plezalisce',
-                route.crag.slug,
-                'smer',
-                route.slug
-              ]"
+              [routerLink]="
+                route.routeType.id == 'alpine'
+                  ? ['/alpinizem/stena', route.crag.slug, 'smer', route.slug]
+                  : ['/plezalisce', route.crag.slug, 'smer', route.slug]
+              "
             >
               <div fxFlex>
                 <a [innerHtml]="highlight(route.name, searchString)"></a>
@@ -139,7 +142,11 @@
               fxLayout="row"
               fxLayoutAlign="start center"
               class="row"
-              [routerLink]="['/plezalisce', sector.crag.slug]"
+              [routerLink]="
+                sector.crag.type == 'alpine'
+                  ? ['/alpinizem/stena', sector.crag.slug]
+                  : ['/plezalisce', sector.crag.slug]
+              "
             >
               <div fxFlex>
                 <a [innerHtml]="highlight(sector.name, searchString)"></a>
@@ -204,12 +211,21 @@
               class="row"
               [routerLink]="
                 comment?.route
-                  ? [
-                      '/plezalisce',
-                      comment.route.crag.slug,
-                      'smer',
-                      comment.route.slug
-                    ]
+                  ? comment.route.routeType.id == 'alpine'
+                    ? [
+                        '/alpinizem/stena',
+                        comment.route.crag.slug,
+                        'smer',
+                        comment.route.slug
+                      ]
+                    : [
+                        '/plezalisce',
+                        comment.route.crag.slug,
+                        'smer',
+                        comment.route.slug
+                      ]
+                  : comment.crag.type == 'alpine'
+                  ? ['/alpinizem/stena', comment.crag.slug]
                   : ['/plezalisce', comment.crag.slug]
               "
             >

--- a/src/app/pages/search/search-results/search-results.component.html
+++ b/src/app/pages/search/search-results/search-results.component.html
@@ -101,7 +101,7 @@
               fxLayoutGap="5px"
               class="row"
               [routerLink]="
-                route.routeType.id == 'alpine'
+                route.crag.type == 'alpine'
                   ? ['/alpinizem/stena', route.crag.slug, 'smer', route.slug]
                   : ['/plezalisce', route.crag.slug, 'smer', route.slug]
               "
@@ -211,7 +211,7 @@
               class="row"
               [routerLink]="
                 comment?.route
-                  ? comment.route.routeType.id == 'alpine'
+                  ? comment.route.crag.type == 'alpine'
                     ? [
                         '/alpinizem/stena',
                         comment.route.crag.slug,

--- a/src/app/pages/search/search-results/search-results.component.ts
+++ b/src/app/pages/search/search-results/search-results.component.ts
@@ -88,14 +88,17 @@ export class SearchResultsComponent implements OnInit {
       return text;
     }
 
-    // strip first and last spaces, then replace all (multiple) middle spaces with single ORs
+    // first escape all special characters. user could be searching for "&" or ">" or "+" and so on...
+    searchString = this.searchService.escape(searchString);
+
+    // strip first and last spaces, then replace all (multiple) middle spaces with regex ORs
     searchString = searchString.trim().replace(/\s+/g, '|');
 
-    // replace csz in search terms with character sets so that all accents are matched
+    // convert characters with possible accents to character groups
     searchString = this.searchService.ignoreAccents(searchString);
 
-    // each term should be a start of a word (start with a non word character (includes closing html >))
-    searchString = '\\b' + searchString + ''; // this fails when accented character is the first character of the word... will do for now
+    // each term should be a start of a string or after a space or after an opening parentheses or after a closing html tag
+    searchString = '(?<=^|\\s|>|\\()' + searchString + '';
 
     // exclude matching text inside html tags
     if (searchingInHtml) {

--- a/src/app/pages/search/search-results/search-results.component.ts
+++ b/src/app/pages/search/search-results/search-results.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { EMPTY, switchMap } from 'rxjs';
 import { LayoutService } from 'src/app/services/layout.service';
+import { SearchService } from 'src/app/shared/services/search.service';
 import { SearchGQL, SearchQuery } from 'src/generated/graphql';
 
 @Component({
@@ -21,7 +22,8 @@ export class SearchResultsComponent implements OnInit {
   constructor(
     private activatedRoute: ActivatedRoute,
     private searchGQL: SearchGQL,
-    private layoutService: LayoutService
+    private layoutService: LayoutService,
+    private searchService: SearchService
   ) {}
 
   ngOnInit(): void {
@@ -90,12 +92,10 @@ export class SearchResultsComponent implements OnInit {
     searchString = searchString.trim().replace(/\s+/g, '|');
 
     // replace csz in search terms with character sets so that all accents are matched
-    searchString = searchString.replace(/[cčć]/gi, '[cčć]');
-    searchString = searchString.replace(/[sš]/gi, '[sš]');
-    searchString = searchString.replace(/[zž]/gi, '[zž]');
+    searchString = this.searchService.ignoreAccents(searchString);
 
     // each term should be a start of a word (start with a non word character (includes closing html >))
-    searchString = '\\b' + searchString + '';
+    searchString = '\\b' + searchString + ''; // this fails when accented character is the first character of the word... will do for now
 
     // exclude matching text inside html tags
     if (searchingInHtml) {

--- a/src/app/pages/search/search-results/search.query.graphql
+++ b/src/app/pages/search/search-results/search.query.graphql
@@ -27,15 +27,13 @@ query Search($query: String) {
       defaultGradingSystem {
         id
       }
-      routeType {
-        id
-      }
       isProject
       length
       crag {
         id
         name
         slug
+        type
         country {
           id
           slug
@@ -80,13 +78,11 @@ query Search($query: String) {
           id
           name
           slug
+          type
           country {
             id
             slug
           }
-        }
-        routeType {
-          id
         }
       }
       user {

--- a/src/app/pages/search/search-results/search.query.graphql
+++ b/src/app/pages/search/search-results/search.query.graphql
@@ -16,6 +16,7 @@ query Search($query: String) {
         id
         slug
       }
+      type
     }
     routes {
       __typename
@@ -24,6 +25,9 @@ query Search($query: String) {
       name
       difficulty
       defaultGradingSystem {
+        id
+      }
+      routeType {
         id
       }
       isProject
@@ -50,6 +54,7 @@ query Search($query: String) {
           id
           slug
         }
+        type
       }
     }
     comments {
@@ -64,6 +69,7 @@ query Search($query: String) {
           id
           slug
         }
+        type
       }
       route {
         __typename
@@ -78,6 +84,9 @@ query Search($query: String) {
             id
             slug
           }
+        }
+        routeType {
+          id
         }
       }
       user {

--- a/src/app/pages/search/search.component.ts
+++ b/src/app/pages/search/search.component.ts
@@ -113,28 +113,40 @@ export class SearchComponent implements OnInit, OnDestroy {
     switch (optionValue.__typename) {
       case 'Crag':
         const crag = optionValue;
-        this.router.navigate(['/plezalisce', crag.slug]);
+
+        this.router.navigate(
+          crag.type == 'alpine'
+            ? ['/alpinizem/stena', crag.slug]
+            : ['/plezalisce', crag.slug]
+        );
+
         break;
 
       case 'Route':
         const route = optionValue;
-        this.router.navigate([
-          '/plezalisce',
-          route.crag.slug,
-          'smer',
-          route.slug,
-        ]);
+
+        this.router.navigate(
+          route.routeType.id == 'alpine'
+            ? ['/alpinizem/stena', route.crag.slug, 'smer', route.slug]
+            : ['/plezalisce', route.crag.slug, 'smer', route.slug]
+        );
         break;
 
       case 'Sector':
         const sector = optionValue;
-        this.router.navigate(['/plezalisce', sector.crag.slug]);
+
+        this.router.navigate(
+          sector.crag.type == 'alpine'
+            ? ['/alpinizem/stena', sector.crag.slug]
+            : ['/plezalisce', sector.crag.slug]
+        );
         break;
 
-      case 'User':
-        const user = optionValue;
-        this.router.navigate(['/uporabniki', user.fullName]);
-        break;
+      // not used until we implement user profile pages
+      // case 'User':
+      //   const user = optionValue;
+      //   this.router.navigate(['/uporabniki', user.fullName]);
+      //   break;
     }
   }
 

--- a/src/app/pages/search/search.component.ts
+++ b/src/app/pages/search/search.component.ts
@@ -126,7 +126,7 @@ export class SearchComponent implements OnInit, OnDestroy {
         const route = optionValue;
 
         this.router.navigate(
-          route.routeType.id == 'alpine'
+          route.crag.type == 'alpine'
             ? ['/alpinizem/stena', route.crag.slug, 'smer', route.slug]
             : ['/plezalisce', route.crag.slug, 'smer', route.slug]
         );

--- a/src/app/pages/search/searchAutoComplete.query.graphql
+++ b/src/app/pages/search/searchAutoComplete.query.graphql
@@ -16,9 +16,7 @@ query SearchAutoComplete($searchString: String) {
       crag {
         id
         slug
-      }
-      routeType {
-        id
+        type
       }
     }
 

--- a/src/app/pages/search/searchAutoComplete.query.graphql
+++ b/src/app/pages/search/searchAutoComplete.query.graphql
@@ -5,6 +5,7 @@ query SearchAutoComplete($searchString: String) {
       id
       name
       slug
+      type
     }
 
     routes {
@@ -16,6 +17,9 @@ query SearchAutoComplete($searchString: String) {
         id
         slug
       }
+      routeType {
+        id
+      }
     }
 
     sectors {
@@ -25,6 +29,7 @@ query SearchAutoComplete($searchString: String) {
       crag {
         id
         slug
+        type
       }
     }
 

--- a/src/app/shared/services/search.service.ts
+++ b/src/app/shared/services/search.service.ts
@@ -19,4 +19,11 @@ export class SearchService {
 
     return searchString;
   }
+
+  /**
+   * Escapes all regex special characters
+   */
+  escape(searchString: string) {
+    return searchString.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+  }
 }

--- a/src/app/shared/services/search.service.ts
+++ b/src/app/shared/services/search.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SearchService {
+  constructor() {}
+
+  ignoreAccents(searchString: string) {
+    searchString = searchString.replace(/[cčć]/gi, '[cčć]');
+    searchString = searchString.replace(/[sš]/gi, '[sš]');
+    searchString = searchString.replace(/[zž]/gi, '[zž]');
+    searchString = searchString.replace(/[aàáâäæãåā]/gi, '[aàáâäæãåā]');
+    searchString = searchString.replace(/[eèéêëēėę]/gi, '[eèéêëēėę]');
+    searchString = searchString.replace(/[iîïíīįì]/gi, '[iîïíīįì]');
+    searchString = searchString.replace(/[oôöòóœøōõ]/gi, '[oôöòóœøōõ]');
+    searchString = searchString.replace(/[uûüùúū]/gi, '[uûüùúū]');
+    searchString = searchString.replace(/[dđ]/gi, '[dđ]');
+
+    return searchString;
+  }
+}


### PR DESCRIPTION
Search yields entities that are mostly sport but might also be of type alpine. 
Alpine routes have own routing under Alpinism and links on search are now properly generated.

To test:
try searching for all the different entity types (crag, sector, route, comment), and for each of them find an example of 'sport' and an example of 'alpine' type.
Determine that all links to these entities are properly generated.


'Internal' search was not working because it did not unaccent characters. Fixes this for most cases. 

To test:
try opening a crag with some routes that have accents in names. eg. smwh in Spain or France.
Se that unaccented characters work for searching for accented characters.


closes #406 
closes #408 

test with https://github.com/plezanje-net/api/pull/128