### PR TITLE
383 star rating calcs update

### DIFF
--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.html
@@ -151,7 +151,10 @@
       ></app-grade-select>
     </div>
 
-    <mat-form-field fxFlex="50" class="no-hint">
+    <mat-form-field
+      fxFlex="50"
+      [ngClass]="{'no-hint':activityFormService.starRatingVotesForRoutes?.[route.value.routeId] == null}"
+    >
       <mat-label>Lepota smeri</mat-label>
       <mat-select formControlName="votedStarRating" class="star-rating">
         <mat-select-trigger>
@@ -176,6 +179,28 @@
           <span><mat-icon>star</mat-icon>Čudovita</span>
         </mat-option>
       </mat-select>
+      <mat-hint
+        class="star-rating-hint"
+        *ngIf="
+          activityFormService.starRatingVotesForRoutes?.[route.value.routeId] != null
+        "
+        ><span>Tvoj trenutni glas:</span>
+        <span
+          *ngIf="activityFormService.starRatingVotesForRoutes?.[route.value.routeId] == 0"
+          class="ml-4"
+          ><span>Nič posebnega</span></span
+        >
+        <span
+          *ngIf="activityFormService.starRatingVotesForRoutes?.[route.value.routeId] == 1"
+          class="ml-4"
+          ><mat-icon>star_border</mat-icon><span>Lepa</span></span
+        >
+        <span
+          *ngIf="activityFormService.starRatingVotesForRoutes?.[route.value.routeId] == 2"
+          class="ml-4"
+          ><mat-icon>star</mat-icon><span>Čudovita</span></span
+        >
+      </mat-hint>
     </mat-form-field>
   </div>
 </div>

--- a/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.scss
+++ b/src/app/activity/forms/activity-form/activity-form-route/activity-form-route.component.scss
@@ -37,3 +37,13 @@ mat-option {
     margin-left: 20px;
   }
 }
+
+.mat-hint.star-rating-hint {
+  display: flex;
+  align-items: center;
+
+  span:last-child {
+    font-weight: 500;
+    display: flex;
+  }
+}

--- a/src/app/activity/forms/activity-form/activity-form.component.ts
+++ b/src/app/activity/forms/activity-form/activity-form.component.ts
@@ -14,6 +14,7 @@ import {
   RoutesTouchesGQL,
   DryRunCreateActivityGQL,
   DryRunUpdateActivityGQL,
+  StarRatingVotesGQL,
 } from 'src/generated/graphql';
 import dayjs from 'dayjs';
 import { Router } from '@angular/router';
@@ -81,7 +82,8 @@ export class ActivityFormComponent implements OnInit, OnDestroy {
     private activityFormService: ActivityFormService,
     private myActivitiesGQL: MyActivitiesGQL,
     private activityEntryGQL: ActivityEntryGQL,
-    private routesTouchesGQL: RoutesTouchesGQL
+    private routesTouchesGQL: RoutesTouchesGQL,
+    private starRatingVotesGQL: StarRatingVotesGQL
   ) {}
 
   ngOnInit(): void {
@@ -104,6 +106,26 @@ export class ActivityFormComponent implements OnInit, OnDestroy {
       this.selectedRoutes.forEach((route) => {
         this.addRoute(route);
       });
+    }
+
+    // Fetch user's previous star rating votes, and display them below the star rating inputs
+    if (this.selectedRoutes?.length) {
+      this.starRatingVotesGQL
+        .fetch({
+          routeIds: this.selectedRoutes.map((route) => route.id),
+        })
+        .subscribe({
+          next: (response) => {
+            const starRatingVotesForRoutes = {};
+            response.data.starRatingVotes.forEach((vote) => {
+              starRatingVotesForRoutes[vote.route.id] = vote.stars;
+            });
+
+            // store it in a service, to be accessed in the form-route component
+            this.activityFormService.starRatingVotesForRoutes =
+              starRatingVotesForRoutes;
+          },
+        });
     }
 
     this.activityForm.controls.date.valueChanges

--- a/src/app/activity/forms/activity-form/activity-form.service.ts
+++ b/src/app/activity/forms/activity-form/activity-form.service.ts
@@ -24,6 +24,8 @@ export class ActivityFormService {
   routesBeingLoggedFormArray: FormArray;
   routesPossibleAscentTypes = []; // This is an array of sets of possible ascentTypes for each route that is being logged. Each element (that is a set) of the array belongs to a route at the same index as it appears on the log form. Each set holds all of the currently possible ascent types for this route.
 
+  starRatingVotesForRoutes: {}; // This is an object of routeId=>stars pairs, that is user's possible previous star rating vote on each route.
+
   constructor() {}
 
   initialize(routes: FormArray) {

--- a/src/app/activity/forms/activity-form/star-rating-votes.query.graphql
+++ b/src/app/activity/forms/activity-form/star-rating-votes.query.graphql
@@ -1,0 +1,9 @@
+query starRatingVotes($routeIds: [String!]!) {
+  starRatingVotes(routeIds: $routeIds) {
+    id
+    stars
+    route {
+      id
+    }
+  }
+}

--- a/src/app/activity/pages/activity-routes/activity-routes.component.ts
+++ b/src/app/activity/pages/activity-routes/activity-routes.component.ts
@@ -256,8 +256,14 @@ export class ActivityRoutesComponent implements OnInit, OnDestroy {
             Če je to tvoj edini uspešni vzpon v tej smeri, boš s tem ${this.genderizeVerbPipe.transform(
               'pobrisal',
               user.gender
-            )} tudi svoj glas o težavnosti te smeri in svojo oceno lepote te smeri.`
+            )} tudi svoj morebitni glas o težavnosti te smeri.`
             : ``;
+
+          finePrint += `<br/>
+            Če je to tvoj edini vzpon v tej smeri, boš s tem ${this.genderizeVerbPipe.transform(
+              'pobrisal',
+              user.gender
+            )} tudi svoj morebitni glas o lepoti te smeri.`;
 
           return this.dialog
             .open(ConfirmationDialogComponent, {

--- a/src/app/pages/crag/crag-by-slug.query.graphql
+++ b/src/app/pages/crag/crag-by-slug.query.graphql
@@ -57,7 +57,6 @@ query CragBySlug($crag: String!) {
         nrClimbers
         position
         starRating
-        nrStarRatingVotes
         publishStatus
       }
       bouldersOnly

--- a/src/app/pages/crag/crag-by-slug.query.graphql
+++ b/src/app/pages/crag/crag-by-slug.query.graphql
@@ -57,6 +57,7 @@ query CragBySlug($crag: String!) {
         nrClimbers
         position
         starRating
+        nrStarRatingVotes
         publishStatus
       }
       bouldersOnly

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -341,14 +341,24 @@
 
                 <td *ngIf="shownColumns.includes('starRating')" class="icon">
                   <mat-icon
-                    *ngIf="math.round(route.starRating) == 1"
-                    title="Lepa"
+                    *ngIf="
+                      math.round(route.starRating) == 1 &&
+                      route.nrStarRatingVotes >= minNrStarRatingVotes
+                    "
+                    title="Lepa ({{
+                      route.nrStarRatingVotes | pluralizeNoun: 'glas'
+                    }})"
                   >
                     star_border
                   </mat-icon>
                   <mat-icon
-                    *ngIf="math.round(route.starRating) == 2"
-                    title="Čudovita"
+                    *ngIf="
+                      math.round(route.starRating) == 2 &&
+                      route.nrStarRatingVotes >= minNrStarRatingVotes
+                    "
+                    title="Čudovita ({{
+                      route.nrStarRatingVotes | pluralizeNoun: 'glas'
+                    }})"
                   >
                     star
                   </mat-icon>
@@ -453,14 +463,24 @@
 
                   <div *ngIf="shownColumns.includes('starRating')" class="star">
                     <mat-icon
-                      *ngIf="math.round(route.starRating) == 1"
-                      title="Lepa"
+                      *ngIf="
+                        math.round(route.starRating) == 1 &&
+                        route.nrStarRatingVotes >= minNrStarRatingVotes
+                      "
+                      title="Lepa ({{
+                        route.nrStarRatingVotes | pluralizeNoun: 'glas'
+                      }})"
                     >
                       star_border
                     </mat-icon>
                     <mat-icon
-                      *ngIf="math.round(route.starRating) == 2"
-                      title="Čudovita"
+                      *ngIf="
+                        math.round(route.starRating) == 2 &&
+                        route.nrStarRatingVotes >= minNrStarRatingVotes
+                      "
+                      title="Čudovita ({{
+                        route.nrStarRatingVotes | pluralizeNoun: 'glas'
+                      }})"
                     >
                       star
                     </mat-icon>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.html
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.html
@@ -340,26 +340,10 @@
                 </td>
 
                 <td *ngIf="shownColumns.includes('starRating')" class="icon">
-                  <mat-icon
-                    *ngIf="
-                      math.round(route.starRating) == 1 &&
-                      route.nrStarRatingVotes >= minNrStarRatingVotes
-                    "
-                    title="Lepa ({{
-                      route.nrStarRatingVotes | pluralizeNoun: 'glas'
-                    }})"
-                  >
+                  <mat-icon *ngIf="route.starRating == 1" title="Lepa">
                     star_border
                   </mat-icon>
-                  <mat-icon
-                    *ngIf="
-                      math.round(route.starRating) == 2 &&
-                      route.nrStarRatingVotes >= minNrStarRatingVotes
-                    "
-                    title="Čudovita ({{
-                      route.nrStarRatingVotes | pluralizeNoun: 'glas'
-                    }})"
-                  >
+                  <mat-icon *ngIf="route.starRating == 2" title="Čudovita">
                     star
                   </mat-icon>
                 </td>
@@ -462,26 +446,10 @@
                   </div>
 
                   <div *ngIf="shownColumns.includes('starRating')" class="star">
-                    <mat-icon
-                      *ngIf="
-                        math.round(route.starRating) == 1 &&
-                        route.nrStarRatingVotes >= minNrStarRatingVotes
-                      "
-                      title="Lepa ({{
-                        route.nrStarRatingVotes | pluralizeNoun: 'glas'
-                      }})"
-                    >
+                    <mat-icon *ngIf="route.starRating == 1" title="Lepa">
                       star_border
                     </mat-icon>
-                    <mat-icon
-                      *ngIf="
-                        math.round(route.starRating) == 2 &&
-                        route.nrStarRatingVotes >= minNrStarRatingVotes
-                      "
-                      title="Čudovita ({{
-                        route.nrStarRatingVotes | pluralizeNoun: 'glas'
-                      }})"
-                    >
+                    <mat-icon *ngIf="route.starRating == 2" title="Čudovita">
                       star
                     </mat-icon>
                   </div>

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -112,8 +112,7 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
       width: 36,
     },
   };
-  math = Math;
-  minNrStarRatingVotes = 3; // The minimun number of star rating votes that a route should have before displaying the star rating
+
   hostResizeObserver: ResizeObserver;
   routeListViewStyle: 'compact' | 'table';
   tableWidth: number;

--- a/src/app/pages/crag/crag-routes/crag-routes.component.ts
+++ b/src/app/pages/crag/crag-routes/crag-routes.component.ts
@@ -113,6 +113,7 @@ export class CragRoutesComponent implements OnInit, OnDestroy {
     },
   };
   math = Math;
+  minNrStarRatingVotes = 3; // The minimun number of star rating votes that a route should have before displaying the star rating
   hostResizeObserver: ResizeObserver;
   routeListViewStyle: 'compact' | 'table';
   tableWidth: number;

--- a/src/app/shared/pipes/genderize-verb.pipe.ts
+++ b/src/app/shared/pipes/genderize-verb.pipe.ts
@@ -4,8 +4,8 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class GenderizeVerbPipe implements PipeTransform {
   transform(verb: string, gender: string) {
-    if (!gender) return verb + '(a)';
     if (gender == 'F') return verb + 'a';
-    return verb;
+    if (gender == 'M') return verb;
+    return verb + '_a';
   }
 }

--- a/src/app/shared/pipes/pluralize-noun.pipe.ts
+++ b/src/app/shared/pipes/pluralize-noun.pipe.ts
@@ -74,6 +74,19 @@ export class PluralizeNoun implements PipeTransform {
             return `${count} uporabniških prispevkov`;
         }
 
+      case 'glas':
+        switch (count % 100) {
+          case 1:
+            return `${count} glas`;
+          case 2:
+            return `${count} glasova`;
+          case 3:
+          case 4:
+            return `${count} glasovi`;
+          default:
+            return `${count} glasov`;
+        }
+
       // A pronoun is a subcategory of nouns
       case 'ga':
         switch (count) {

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -80,6 +80,9 @@ p.mt-16,
 .mb-32 {
   margin-bottom: 32px;
 }
+.ml-4 {
+  margin-left: 4px;
+}
 .ml-16 {
   margin-left: 16px;
 }


### PR DESCRIPTION
a.
~~Hides stars from route list unless at least N star ratings are cast. N is set to 3 now. Seems better/ok now, but might discuss this and alter this constant.~~
I vote for making it even more conservative or leaving it as is. I believe stars should be used sparingly and shown on routes where there really is a somewhat 'wide' consensus on the route's beauty.

But...
this may only postpone the same problem we have now... (to many routes with stars).
I fear that we will eventually come to all routes having some votes and most of them will average out to 1 star...

Maybe consider another way of determining stars shown?
only show stars if one of the possible starRatings has some predefined majority?
eg.:
0stars: 100 votes
1star: 100 votes
2stars: 100 votes
would now show one star

but if we define some 'majoritywise' condition, it might show no star, which would make sense, as consensus on the routes beauty in the above example has not been met.
this could for example be: 'show star rating if at least 50% of votes is of one kind'. 
same example would now show no stars, but
e.g.:
0stars: 100 votes
1star: 100 votes
2stars: 201 vote
would show two stars
which might make more sense, as more than half of the voters agree that this should be a 2star route...



b.
Displays user's current starRating for a route, when a user is on the log form.

To test:
a. Pull live db to local, then open e.g. 'Kotečnik' crag and see how many routes have stars. 

b. log some routes, give star rating. then loge same routes again and see that your previous star rating gets displayed in a hint.


update: 
calc of star ratings are done on BE now. see linked PR. It is done more or less as suggested above with some additional conditions as discussed.


Test this with: https://github.com/plezanje-net/api/pull/133

closes #383 