### PR TITLE
Open filtered log from crag and route page

### DIFF
--- a/src/app/pages/crag/crag-info/crag-info.component.html
+++ b/src/app/pages/crag/crag-info/crag-info.component.html
@@ -52,3 +52,15 @@
     fxFlexAlign="stretch"
   ></app-distribution-chart>
 </div>
+
+<div class="card no-border padding" *ngIf="user">
+  <h4>Moji obiski</h4>
+  <button
+    mat-button
+    color="primary"
+    fxFill
+    [routerLink]="['/plezalni-dnevnik', { cragId: crag.id }]"
+  >
+    Prikaži v plezalnem dnevniku
+  </button>
+</div>

--- a/src/app/pages/crag/crag-info/crag-info.component.ts
+++ b/src/app/pages/crag/crag-info/crag-info.component.ts
@@ -1,6 +1,7 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnDestroy, OnInit } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { Crag } from 'src/generated/graphql';
+import { AuthService } from 'src/app/auth/auth.service';
+import { Crag, User } from 'src/generated/graphql';
 import { IDistribution } from '../../../common/distribution-chart/distribution-chart.component';
 
 @Component({
@@ -8,7 +9,7 @@ import { IDistribution } from '../../../common/distribution-chart/distribution-c
   templateUrl: './crag-info.component.html',
   styleUrls: ['./crag-info.component.scss'],
 })
-export class CragInfoComponent implements OnInit, OnChanges {
+export class CragInfoComponent implements OnInit, OnChanges, OnDestroy {
   @Input() crag: Crag;
 
   @Input() id: string = 'default';
@@ -16,15 +17,26 @@ export class CragInfoComponent implements OnInit, OnChanges {
   attendanceDistribution: IDistribution[] = [];
 
   crags$ = new BehaviorSubject<any>([]);
+  user: User;
+  subscriptions = [];
 
-  constructor() {}
+  constructor(private authService: AuthService) {}
 
   ngOnInit(): void {
     this.init();
+
+    const userSub = this.authService.currentUser.subscribe(
+      (user) => (this.user = user)
+    );
+    this.subscriptions.push(userSub);
   }
 
   ngOnChanges(): void {
     this.init();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((s) => s.unsubscribe());
   }
 
   init() {

--- a/src/app/pages/route/route-info/route-info.component.html
+++ b/src/app/pages/route/route-info/route-info.component.html
@@ -83,6 +83,18 @@
   ></app-route-grades>
 </div>
 
+<div class="card no-border padding" *ngIf="user">
+  <h4>Moji vzponi</h4>
+  <button
+    mat-button
+    color="primary"
+    fxFill
+    [routerLink]="['/plezalni-dnevnik/vzponi', { routeId: route.id }]"
+  >
+    Prikaži v plezalnem dnevniku
+  </button>
+</div>
+
 <div class="card no-border">
   <h2>Popularnost smeri</h2>
   <div class="row" fxLayout="row" fxLayoutAlign="space-between center">

--- a/src/app/pages/route/route-info/route-info.component.ts
+++ b/src/app/pages/route/route-info/route-info.component.ts
@@ -1,14 +1,15 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, OnDestroy } from '@angular/core';
 import { IDistribution } from '../../../common/distribution-chart/distribution-chart.component';
 import { GradeDistributionService } from 'src/app/shared/services/grade-distribution.service';
-import { Route } from 'src/generated/graphql';
+import { Route, User } from 'src/generated/graphql';
+import { AuthService } from 'src/app/auth/auth.service';
 
 @Component({
   selector: 'app-route-info',
   templateUrl: './route-info.component.html',
   styleUrls: ['./route-info.component.scss'],
 })
-export class RouteInfoComponent implements OnInit {
+export class RouteInfoComponent implements OnInit, OnDestroy {
   @Input() route: Route;
   grades: any[];
   hideGrade = false;
@@ -25,7 +26,13 @@ export class RouteInfoComponent implements OnInit {
     RB: 'Preopremil_a',
   };
 
-  constructor(private gradeDistributionService: GradeDistributionService) {}
+  user: User;
+  subscriptions = [];
+
+  constructor(
+    private gradeDistributionService: GradeDistributionService,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {
     if (this.route) {
@@ -43,5 +50,14 @@ export class RouteInfoComponent implements OnInit {
       this.route.properties.find(
         (property) => property.propertyType.id == 'extGrade'
       ) != null;
+
+    const userSub = this.authService.currentUser.subscribe(
+      (user) => (this.user = user)
+    );
+    this.subscriptions.push(userSub);
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach((s) => s.unsubscribe());
   }
 }


### PR DESCRIPTION
To test - test the buttons in crag and route info that appear only for logged in users.

The long term idea is to display last few ascents / activities with the link and to hide this if there is no history with this crag/route. 
This will probably be addressed after the FE rework and is not part of this PR.