### PR TITLE
Fix bug where a route' base grade cannot be edited

### DIFF
--- a/src/app/management/forms/route-form/route-form.component.ts
+++ b/src/app/management/forms/route-form/route-form.component.ts
@@ -199,7 +199,7 @@ export class RouteFormComponent implements OnInit, OnDestroy {
       (route?.difficultyVotes.length == 0 ||
         (route?.difficultyVotes.length == 1 &&
           route?.difficultyVotes[0].isBase)) &&
-      route.nrTries === 0
+      !route.nrTries
     );
   }
 


### PR DESCRIPTION
A route with no ascents should let admins edit it's grade.

nrTries can be null as it seems and in this case the condition ==0 is wrong.
should also check api why


