### PR TITLE
Display notice in management if crag has only dummy sector.

### DIFF
--- a/src/app/management/pages/crag-sectors/crag-sectors.component.html
+++ b/src/app/management/pages/crag-sectors/crag-sectors.component.html
@@ -21,6 +21,15 @@
 
   <div class="container p15 mt-16">
     <div
+      *ngIf="sectors.length === 1 && !sectors[0].label && !sectors[0].name"
+      class="noname notice"
+    >
+      Če je to plezališče brez sektorjev, nadaljuj z urejanjem smeri v sektorju
+      brez imena. Če je to plezališče z več sektorji, najprej uredi sektor brez
+      imena, tako da mu spremeniš ime, nato pa dodaj še druge sektorje.
+    </div>
+
+    <div
       cdkDropList
       (cdkDropListDropped)="drop($event)"
       [class.saving]="savingPositions"
@@ -42,6 +51,11 @@
           }"
         >
           <div class="name" fxFlex="100" fxFlex.lt-sm>
+            <span
+              *ngIf="sectors.length == 1 && !sector.label && !sector.name"
+              class="noname"
+              >Brez imena</span
+            >
             <span>{{ sector.label }}</span> {{ sector.name }}
           </div>
           <div fxFlex>

--- a/src/app/management/pages/crag-sectors/crag-sectors.component.scss
+++ b/src/app/management/pages/crag-sectors/crag-sectors.component.scss
@@ -63,3 +63,12 @@
     }
   }
 }
+
+.noname {
+  color: $text-gray;
+  font-style: italic;
+}
+
+.notice {
+  padding: 12px;
+}


### PR DESCRIPTION
When a new crag is created, BE will create a dummy sector (no name, no label) - when this PR is merged: https://github.com/plezanje-net/api/pull/179

A message is now displayed instructing the user to either use this dummy sector as is in case of a sectorless crag, or to rename it in case of a crag with many sectors.